### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This command will install the `eigenlayer` executable along with the library and
 > As the repository is private, you need to set the `GOPRIVATE` variable properly by running the following command: `export GOPRIVATE=github.com/Layr-Labs/eigenlayer-cli,$GOPRIVATE`. Git will automatically resolve the private access if your Git user has all the required permissions over the repository.
 
 ```bash
-go install github.com/Layr-Labs/eigenlayer/cmd/eigenlayer@latest
+go install github.com/Layr-Labs/eigenlayer-cli/cmd/eigenlayer@latest
 ```
 
 The executable will be in your `$GOBIN` (`$GOPATH/bin`).


### PR DESCRIPTION
The current URL that we are using to install eigenlayer-cli with go was not correct. I changed it with the correct url.

### Motivation

The current command solves the installation with Go. The previous one was incorrect.

### Solution

Just added `-cli` to the URL

