### PR TITLE
confirm password when a new key is creating

### DIFF
--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -29,7 +29,6 @@ const (
 )
 
 func CreateCmd(p utils.Prompter) *cli.Command {
-
 	createCmd := &cli.Command{
 		Name:      "create",
 		Usage:     "Used to create encrypted keys in local keystore",
@@ -119,6 +118,18 @@ func saveBlsKey(keyName string, p utils.Prompter, keyPair *bls.KeyPair, insecure
 		return err
 	}
 
+	_, err = p.InputHiddenString("Please confirm your password:", "",
+		func(s string) error {
+			if s != password {
+				return errors.New("passwords are not matched")
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return err
+	}
+
 	err = keyPair.SaveToFile(fileLoc, password)
 	if err != nil {
 		return err
@@ -149,6 +160,19 @@ func saveEcdsaKey(keyName string, p utils.Prompter, privateKey *ecdsa.PrivateKey
 				return nil
 			}
 			return validatePassword(s)
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	_, err = p.InputHiddenString("Please confirm your password:", "",
+
+		func(s string) error {
+			if s != password {
+				return errors.New("passwords are not matched")
+			}
+			return nil
 		},
 	)
 	if err != nil {

--- a/pkg/operator/keys/create_test.go
+++ b/pkg/operator/keys/create_test.go
@@ -75,6 +75,7 @@ func TestCreateCmd(t *testing.T) {
 			err:  nil,
 			promptMock: func(p *prompterMock.MockPrompter) {
 				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 			},
 			keyPath: filepath.Join(homePath, OperatorKeystoreSubFolder, "/do_not_use_this_name.ecdsa.key.json"),
 		},
@@ -83,6 +84,7 @@ func TestCreateCmd(t *testing.T) {
 			args: []string{"--key-type", "bls", "do_not_use_this_name"},
 			err:  nil,
 			promptMock: func(p *prompterMock.MockPrompter) {
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 			},
 			keyPath: filepath.Join(homePath, OperatorKeystoreSubFolder, "/do_not_use_this_name.bls.key.json"),

--- a/pkg/operator/keys/import_test.go
+++ b/pkg/operator/keys/import_test.go
@@ -106,6 +106,7 @@ func TestImportCmd(t *testing.T) {
 			err: nil,
 			promptMock: func(p *prompterMock.MockPrompter) {
 				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 			},
 			expectedPrivKey: "6842fb8f5fa574d0482818b8a825a15c4d68f542693197f2c2497e3562f335f6",
 			keyPath:         filepath.Join(homePath, OperatorKeystoreSubFolder, "/test.ecdsa.key.json"),
@@ -120,6 +121,7 @@ func TestImportCmd(t *testing.T) {
 			},
 			err: nil,
 			promptMock: func(p *prompterMock.MockPrompter) {
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 			},
 			expectedPrivKey: "6842fb8f5fa574d0482818b8a825a15c4d68f542693197f2c2497e3562f335f6",
@@ -136,6 +138,7 @@ func TestImportCmd(t *testing.T) {
 			err: nil,
 			promptMock: func(p *prompterMock.MockPrompter) {
 				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 			},
 			expectedPrivKey: "20030410000080487431431153104351076122223465926814327806350179952713280726583",
 			keyPath:         filepath.Join(homePath, OperatorKeystoreSubFolder, "/test.bls.key.json"),
@@ -150,6 +153,7 @@ func TestImportCmd(t *testing.T) {
 			},
 			err: nil,
 			promptMock: func(p *prompterMock.MockPrompter) {
+				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 				p.EXPECT().InputHiddenString(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil)
 			},
 			expectedPrivKey: "5491383829988096583828972342810831790467090979842721151380259607665538989821",


### PR DESCRIPTION
Fixes # .

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

When user try to create a new key by using `eigenlayer`, the user should enter a password to encrypt keystore. But there is no password confirmation steps even thought the password is very important.

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

Add a new simple step to confirm password.

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->