### PR TITLE
Bold green text and emojis on the key creation to save private key hex

### DIFF
--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -187,8 +187,7 @@ func saveEcdsaKey(keyName string, p utils.Prompter, privateKey *ecdsa.PrivateKey
 	privateKeyHex := hex.EncodeToString(privateKey.D.Bytes())
 	// TODO: display it using `less` of `vi` so that it is not saved in terminal history
 	fmt.Println("ECDSA Private Key (Hex): ", privateKeyHex)
-	fmt.Println("Please backup the above private key hex in safe place.")
-	fmt.Println()
+	fmt.Println("\033[1;32m🔐 Please backup the above private key hex in a safe place 🔒\033[0m")
 	fmt.Println("Key location: " + fileLoc)
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)


### PR DESCRIPTION
Fixes #29

### Motivation
Update to the issue #29 with adding bold text and emojis as discussed.

### Solution
Added syntax for changing text color and emoji unicode

![image](https://github.com/Layr-Labs/eigenlayer-cli/assets/83395536/7b570074-8b97-4601-bd5b-7625a223bf05)

### Open questions
Will look into fixing the TODO in the code with using `less` with `vi`