### PR TITLE
Displaying sensitive information during key creation with using `less` so is not saved in terminal history

### DIFF
--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -185,20 +185,17 @@ func saveEcdsaKey(keyName string, p utils.Prompter, privateKey *ecdsa.PrivateKey
 	}
 
 	privateKeyHex := hex.EncodeToString(privateKey.D.Bytes())
-	// TODO: display it using `less` of `vi` so that it is not saved in terminal history
-	fmt.Println("ECDSA Private Key (Hex): ", privateKeyHex)
-	fmt.Println("\033[1;32m🔐 Please backup the above private key hex in a safe place 🔒\033[0m")
-	fmt.Println("Key location: " + fileLoc)
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		return err
+		return errors.New("error casting public key to ECDSA public key")
 	}
 	publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
-	fmt.Println("Public Key hex: ", hexutil.Encode(publicKeyBytes)[4:])
+	publicKeyHex := hexutil.Encode(publicKeyBytes)[4:]
 	address := crypto.PubkeyToAddress(*publicKeyECDSA).Hex()
-	fmt.Println("Ethereum Address", address)
-	return nil
+
+	return displayWithLess(fileLoc, privateKeyHex, fileLoc, publicKeyHex, address, KeyTypeECDSA)
+}
 }
 
 func checkIfKeyExists(fileLoc string) bool {

--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -140,7 +140,8 @@ func saveBlsKey(keyName string, p utils.Prompter, keyPair *bls.KeyPair, insecure
     privateKeyHex := keyPair.PrivKey.String()
     publicKeyHex := keyPair.PubKey.String()
 
-    return displayWithLess(fileLoc, privateKeyHex, fileLoc, publicKeyHex, "", KeyTypeBLS)
+    fmt.Printf("\nKey location: %s\nPublic Key: %s\n\n", fileLoc, publicKeyHex)
+    return displayWithLess(privateKeyHex, KeyTypeBLS)
 }
 
 func saveEcdsaKey(keyName string, p utils.Prompter, privateKey *ecdsa.PrivateKey, insecure bool) error {

--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -195,7 +195,8 @@ func saveEcdsaKey(keyName string, p utils.Prompter, privateKey *ecdsa.PrivateKey
 	publicKeyHex := hexutil.Encode(publicKeyBytes)[4:]
 	address := crypto.PubkeyToAddress(*publicKeyECDSA).Hex()
 
-	return displayWithLess(fileLoc, privateKeyHex, fileLoc, publicKeyHex, address, KeyTypeECDSA)
+    fmt.Printf("\nKey location: %s\nPublic Key hex: %s\nEthereum Address: %s\n\n", fileLoc, publicKeyHex, address)
+    return displayWithLess(privateKeyHex, KeyTypeECDSA)
 }
 
 func displayWithLess(filePath, privateKeyHex, fileLoc, publicKeyHex, address, keyType string) error {

--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -132,6 +132,16 @@ func saveBlsKey(keyName string, p utils.Prompter, keyPair *bls.KeyPair, insecure
 		}
 	}
 
+	err = keyPair.SaveToFile(fileLoc, password)
+    if err != nil {
+        return err
+    }
+
+    privateKeyHex := keyPair.PrivKey.String()
+    publicKeyHex := keyPair.PubKey.String()
+
+    fmt.Printf("\nKey location: %s\nPublic Key: %s\n\n", fileLoc, publicKeyHex)
+    return displayWithLess(privateKeyHex, KeyTypeBLS)
 }
 
 func saveEcdsaKey(

--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -132,17 +132,15 @@ func saveBlsKey(keyName string, p utils.Prompter, keyPair *bls.KeyPair, insecure
 		return err
 	}
 
-	err = keyPair.SaveToFile(fileLoc, password)
-	if err != nil {
-		return err
-	}
-	// TODO: display it using `less` of `vi` so that it is not saved in terminal history
-	fmt.Println("BLS Private Key: " + keyPair.PrivKey.String())
-	fmt.Println("Please backup the above private key in safe place.")
-	fmt.Println()
-	fmt.Println("BLS Pub key: " + keyPair.PubKey.String())
-	fmt.Println("Key location: " + fileLoc)
-	return nil
+    err = keyPair.SaveToFile(fileLoc, password)
+    if err != nil {
+        return err
+    }
+
+    privateKeyHex := keyPair.PrivKey.String()
+    publicKeyHex := keyPair.PubKey.String()
+
+    return displayWithLess(fileLoc, privateKeyHex, fileLoc, publicKeyHex, "", KeyTypeBLS)
 }
 
 func saveEcdsaKey(keyName string, p utils.Prompter, privateKey *ecdsa.PrivateKey, insecure bool) error {

--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"

--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -196,6 +196,7 @@ func saveEcdsaKey(keyName string, p utils.Prompter, privateKey *ecdsa.PrivateKey
 
 	return displayWithLess(fileLoc, privateKeyHex, fileLoc, publicKeyHex, address, KeyTypeECDSA)
 }
+
 func displayWithLess(filePath, privateKeyHex, fileLoc, publicKeyHex, address, keyType string) error {
     var message, border, keyLine string
     tabSpace := "    " 

--- a/pkg/operator/keys/create.go
+++ b/pkg/operator/keys/create.go
@@ -199,7 +199,7 @@ func saveEcdsaKey(keyName string, p utils.Prompter, privateKey *ecdsa.PrivateKey
     return displayWithLess(privateKeyHex, KeyTypeECDSA)
 }
 
-func displayWithLess(filePath, privateKeyHex, fileLoc, publicKeyHex, address, keyType string) error {
+func displayWithLess(privateKeyHex string, keyType string) error {
     var message, border, keyLine string
     tabSpace := "    " 
 
@@ -222,16 +222,10 @@ ECDSA Private Key (Hex):
 
 🔐 Please backup the above private key hex in a safe place 🔒
 
-Key location: %s
-
-Public Key hex: %s
-
-Ethereum Address: %s
-
-`, border, paddingLine, keyLine, paddingLine, border, fileLoc, publicKeyHex, address)
+`, border, paddingLine, keyLine, paddingLine, border)
     } else if keyType == KeyTypeBLS {
         message = fmt.Sprintf(`
-BLS Private Key Information:
+BLS Private Key (Hex):
 
 %s
 %s
@@ -239,15 +233,9 @@ BLS Private Key Information:
 %s
 %s
 
-🔐 Please backup the above private key in a safe place 🔒
+🔐 Please backup the above private key hex in a safe place 🔒
 
-Public Key: %s
-
-Key location: %s
-
-`, border, paddingLine, keyLine, paddingLine, border, publicKeyHex, fileLoc)
-    } else {
-        return fmt.Errorf("unsupported key type: %s", keyType)
+`, border, paddingLine, keyLine, paddingLine, border)
     }
 
     cmd := exec.Command("less", "-R")


### PR DESCRIPTION
Fixes the TODO in the code for displaying sensitive information in: 
https://github.com/Layr-Labs/eigenlayer-cli/blob/754ca6832861c6b1d9df3d507c04365efea70401/pkg/operator/keys/create.go#L137-L143
and
https://github.com/Layr-Labs/eigenlayer-cli/blob/754ca6832861c6b1d9df3d507c04365efea70401/pkg/operator/keys/create.go#L188-L196
### Motivation
- Increased Security: By removing direct terminal outputs of private keys, we significantly reduce the risk of sensitive data exposure. This change is crucial for users who manage keys in shared or insecure environments.

- Improved Usability: The introduction of a formatted display for key information, including private and public keys, addresses, and file locations, enhances clarity and user experience. This structured presentation makes it easier for users to securely manage and backup their key information.

- Error Handling and Validation: Enhancements in error handling and input validation further contribute to the robustness of key management.

### Solution
The solution of how to secure the display of key information was to implement a function that displays the key details securely using less, avoiding direct terminal output. A new function called `displayWithLess` is introduced and called in the `saveBlsKey` and `saveEcdsaKey`. The ASCII art is dynamically generated by taking the length and calculating padding for a nice format. 

### Open questions
Would like feedback on the ASCII art and how we would improve more clarity on the saving of the hash or key (regarding bls or ecdsa) since it is not quite intuitive to add colours with the `less` command.

### Pictures

BLS Private key

![image](https://github.com/Layr-Labs/eigenlayer-cli/assets/83395536/e9db483e-9678-4e94-a4a6-f8a296b4164a)


ECDSA Private key generation

![image](https://github.com/Layr-Labs/eigenlayer-cli/assets/83395536/2aa91c18-3b19-4649-b18a-8ee75b2e5a30)

