### PR TITLE
add delegation manager address to operator-config-example-yaml

### DIFF
--- a/pkg/operator/config/operator-config-example.yaml
+++ b/pkg/operator/config/operator-config-example.yaml
@@ -22,7 +22,7 @@ operator:
 
 # EigenLayer Delegation manager contract address
 # This will be provided by EigenLayer team
-el_delegation_manager_address:
+el_delegation_manager_address: 0x1b7b8F6b258f95Cf9596EabB9aa18B62940Eb0a8
 
 # ETH RPC URL to the ethereum node you are using for on-chain operations
 eth_rpc_url: http://localhost:8545


### PR DESCRIPTION


Fixes # .

### Motivation
It might be helpful if we add the correct delegation managaer address to example YAML file. It should be updated in case of delegation manager address changes

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->