### PR TITLE
Update README and improve error messages in register.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ sudo cp $GOPATH/bin/eigenlayer /usr/local/bin/
 # Build from source
 sudo cp eigenlayer-cli/build/eigenlayer /usr/local/bin/
 ```
+## Update `eigenlayer` CLI from source
+To update your eigenlayer CLI, go to its local repository, pull updates, and rebuild
+```bash
+cd eigenlayer-cli  
+git pull origin master
+```
+Rebuild the eigenlayer binary with the latest changes:
+```bash
+# If using Go directly
+go build -o build/eigenlayer cmd/eigenlayer/main.go
+```
+```bash
+# Or if you're using make
+make build
+```
+Replace the existing binary in your system with the newly built one:
+```bash
+sudo cp build/eigenlayer /usr/local/bin/eigenlayer
+```
+Verify the update by checking the version of eigenlayer:
+```bash
+eigenlayer --version
+```
 
 ## Documentation
 Please refer to the full documentation [here](https://docs.eigenlayer.xyz/operator-guides/operator-installation).

--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -150,7 +150,7 @@ func validateAndMigrateConfigFile(path string) (*types.OperatorConfigNew, error)
 	var operatorCfgOld types.OperatorConfig
 	err := utils.ReadYamlConfig(path, &operatorCfgOld)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read or parse the YAML configuration file at '%s': %w", path, err)
 	}
 	if operatorCfgOld.ELSlasherAddress != "" || operatorCfgOld.BlsPublicKeyCompendiumAddress != "" {
 		fmt.Printf("%s Old config detected, migrating to new config\n", utils.EmojiCheckMark)


### PR DESCRIPTION
**# Motivation**
There are many projects that use/will use CLI and there were some points that caught my attention while installing Mangata.

* **Error Handling:**  Our error messages around configuration files could really use some work. Let's make them more specific about what's going wrong (file not found, bad format, etc.), give them the file path, and maybe even suggest some troubleshooting steps

* **Upgrade Instructions:** It'd be awesome to have a clear guide on updating the CLI right from the source 

**# Solution**
* **Error Handling:** Tweaked the functions that deal with config files to give way better error messages

* **Upgrade Instructions:** Added some simple upgrade steps either in the README separate

**# Open Questions**
* Could we make those error messages even better? Any ideas on what else to include?
* Should the upgrade instructions be more specific depending on the operating system?