### PR TITLE
[operator config] Add --yes flag to skip prompt

### DIFF
--- a/pkg/operator/config/create.go
+++ b/pkg/operator/config/create.go
@@ -27,22 +27,28 @@ func CreateCmd(p utils.Prompter) *cli.Command {
 
 		Both of these are needed for operator registration
 		`,
+		Flags: []cli.Flag{
+			&YesFlag,
+		},
 		Action: func(ctx *cli.Context) error {
+			skipPrompt := ctx.Bool(YesFlag.Name)
+
 			op := types.OperatorConfigNew{}
 
-			// Prompt user to generate empty or non-empty files
-			populate, err := p.Confirm("Would you like to populate the operator config file?")
-			if err != nil {
-				return err
-			}
-
-			if populate {
-				op, err = promptOperatorInfo(&op, p)
+			if !skipPrompt {
+				// Prompt user to generate empty or non-empty files
+				populate, err := p.Confirm("Would you like to populate the operator config file?")
 				if err != nil {
 					return err
 				}
-			}
 
+				if populate {
+					op, err = promptOperatorInfo(&op, p)
+					if err != nil {
+						return err
+					}
+				}
+			}
 			yamlData, err := yaml.Marshal(&op)
 			if err != nil {
 				return err

--- a/pkg/operator/config/create_test.go
+++ b/pkg/operator/config/create_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	prompterMock "github.com/Layr-Labs/eigenlayer-cli/pkg/utils/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCreateCmd_WithYesFlag(t *testing.T) {
+	// Arrange
+	controller := gomock.NewController(t)
+	prompter := prompterMock.NewMockPrompter(controller)
+
+	cmd := CreateCmd(prompter)
+	app := cli.NewApp()
+	flags := []string{"--yes"}
+
+	// Expect that the prompter will not be called
+	prompter.EXPECT().Confirm(gomock.Any()).Times(0)
+
+	// // We do this because the in the parsing of arguments it ignores the first argument
+	// // for commands, so we add a blank string as the first argument
+	// // I suspect it does this because it is expecting the first argument to be the name of the command
+	// // But when we are testing the command, we don't want to have to specify the name of the command
+	// // since we are creating the command ourselves
+	// // https://github.com/urfave/cli/blob/c023d9bc5a3122830c9355a0a8c17137e0c8556f/command.go#L323
+	args := append([]string{""}, flags...)
+
+	cCtx := cli.NewContext(app, nil, &cli.Context{Context: context.Background()})
+
+	// Act
+	err := cmd.Run(cCtx, args...)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.FileExists(t, "operator.yaml")
+	assert.FileExists(t, "metadata.json")
+}

--- a/pkg/operator/config/flags.go
+++ b/pkg/operator/config/flags.go
@@ -1,0 +1,12 @@
+package config
+
+import "github.com/urfave/cli/v2"
+
+var (
+	YesFlag = cli.BoolFlag{
+		Name:    "yes",
+		Aliases: []string{"y"},
+		Usage:   "Use this flag to skip confirmation prompts. When used the operator config file and metadata file will be created with default values.",
+		EnvVars: []string{"YES"},
+	}
+)


### PR DESCRIPTION
### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->
The current `eigenlayer operator config create` command is interactive only, and using tools like `expect` does not work because the prompt library the CLI is using sends a weird `^[[61;169R` cursor code that doesn't allow a proper expect/send pipeline. 

I'm creating Ansible playbooks to automate the registration process of an AVS Operator, among other operations related to AVS Operator duties. I can't automate the registration process fully without solving this problem

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->
Adding a `--yes/-y` flag to skip the confirmation prompt allows automating the `eigenlayer operator config create` call, creating the `operator.yaml` and `metadata.json` files just as if you press enter in the current and interactive mode.

This kind of proposed behavior is quite standard in CLI applications.
