### PR TITLE
feat: revert if delegation manager is missing

### DIFF
--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -56,6 +56,10 @@ func RegisterCmd(p utils.Prompter) *cli.Command {
 				return fmt.Errorf("%w: with error %s", ErrInvalidYamlFile, err)
 			}
 
+			if operatorCfg.ELDelegationManagerAddress == "" {
+				return fmt.Errorf("\n%w: ELDelegationManagerAddress is not set", ErrInvalidYamlFile)
+			}
+
 			fmt.Printf(
 				"\r%s Operator configuration file validated successfully %s\n",
 				utils.EmojiCheckMark,


### PR DESCRIPTION
### Motivation
If delegation manager address key is missing in the .env user would be receiving misleading error about Slasher address: 
```
Failed to fetch Slasher address: no contract code at given address
```

### Solution
Added check for non empty ELDelegationManagerAddress in the config reverting with relevant error message