### PR TITLE
clarify error message

### DIFF
--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -53,17 +53,6 @@ func RegisterCmd(p utils.Prompter) *cli.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Printf(
-				"%s Operator configuration file read successfully %s\n",
-				utils.EmojiCheckMark,
-				operatorCfg.Operator.Address,
-			)
-			fmt.Printf("%s validating operator config: %s ... ", utils.EmojiWait, operatorCfg.Operator.Address)
-
-			err = operatorCfg.Operator.Validate()
-			if err != nil {
-				return fmt.Errorf("%w: %s", ErrInvalidYamlFile, err.Error())
-			}
 
 			fmt.Printf(
 				"\r%s Operator configuration file validated successfully %s\n",
@@ -270,7 +259,7 @@ func validateAndReturnConfig(configurationFilePath string) (*types.OperatorConfi
 
 	err = operatorCfg.Operator.Validate()
 	if err != nil {
-		return nil, fmt.Errorf("%w: with error %s", ErrInvalidYamlFile, err.Error())
+		return nil, fmt.Errorf("\r%w: with error %s", ErrInvalidYamlFile, err.Error())
 	}
 
 	err = validateMetadata(operatorCfg)

--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -53,6 +53,17 @@ func RegisterCmd(p utils.Prompter) *cli.Command {
 			if err != nil {
 				return err
 			}
+			fmt.Printf(
+				"%s Operator configuration file read successfully %s\n",
+				utils.EmojiCheckMark,
+				operatorCfg.Operator.Address,
+			)
+			fmt.Printf("%s validating operator config: %s ... ", utils.EmojiWait, operatorCfg.Operator.Address)
+
+			err = operatorCfg.Operator.Validate()
+			if err != nil {
+				return fmt.Errorf("%w: %s", ErrInvalidYamlFile, err.Error())
+			}
 
 			fmt.Printf(
 				"\r%s Operator configuration file validated successfully %s\n",


### PR DESCRIPTION
Very minor update, and arguably opinionated. Adds spacing between the operator address and subsequent error message. Also explicitly uses the string returned by `err.Error()`, and removes a redundant `with error`. Happy to add that back in though!

Before (assuming address == `0xabcd`)
```
validating operator config: 0xabcdinvalid yaml file: with error invalid image extension. only .pngis supported
```

After
```
validating operator config: 0xabcd ... invalid yaml file: invalid image extension. only .pngis supported
```

(I'm aware the spacing of `.pngis supported` was addressed here: https://github.com/andrewkmin/eigensdk-go/commit/16ddf1b87f57f6ca5996678bdc8d50646286f2f6)

### Motivation
<!--
Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
-->

Readability

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->