### PR TITLE
Replace goerli chain id with holesky in example operator config

### DIFF
--- a/pkg/operator/config/operator-config-example.yaml
+++ b/pkg/operator/config/operator-config-example.yaml
@@ -35,4 +35,4 @@ signer_type: local_keystore
 private_key_store_path: <path-to>/test.ecdsa.key.json
 
 # Chain ID: 1 for mainnet, 17000 for holesky, 31337 for local
-chain_id: 5
+chain_id: 17000


### PR DESCRIPTION
### Fixes
Our example operator config referenced https://docs.eigenlayer.xyz/eigenlayer/operator-guides/operator-installation#operator-registration is broken

If operator uses that template and does not update the chain id, they will have bunch of esoteric opt-in failures.

### Motivation
Reduced cognitive load on new operator debugging opt-in

### Solution
Update chain id to holesky