### PR TITLE
support ~ in path

### DIFF
--- a/pkg/operator/update.go
+++ b/pkg/operator/update.go
@@ -67,6 +67,14 @@ func UpdateCmd(p utils.Prompter) *cli.Command {
 				}
 			}
 
+			// This is to expand the tilde in the path to the home directory
+			// This is not supported by Go's standard library
+			keyFullPath, err := expandTilde(operatorCfg.PrivateKeyStorePath)
+			if err != nil {
+				return err
+			}
+			operatorCfg.PrivateKeyStorePath = keyFullPath
+
 			signerCfg := signerv2.Config{
 				KeystorePath: operatorCfg.PrivateKeyStorePath,
 				Password:     ecdsaPassword,


### PR DESCRIPTION
Fixes #98  .

### Motivation
Go by default doesn't support tilde so converting from tilde to full path

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->