### PR TITLE
remove old config

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,16 +1,4 @@
 Fixes # .
 
-### Motivation
-<!--
-Does this solve a bug? Enable a new use-case? Improve an existing behavior? Concrete examples are helpful here.
--->
-
-### Solution
-<!--
-What is the solution here from a high level. What are the key technical decisions and why were they made?
--->
-
-### Open questions
-<!--
-(optional) Any open questions or feedback on design desired?
--->
+### What Changed?
+<! -- Describe the changes you made in this PR -->

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -32,7 +32,7 @@ func StatusCmd(p utils.Prompter) *cli.Command {
 			}
 
 			configurationFilePath := args.Get(0)
-			operatorCfg, err := validateAndMigrateConfigFile(configurationFilePath)
+			operatorCfg, err := readConfigFile(configurationFilePath)
 			if err != nil {
 				return err
 			}

--- a/pkg/types/operator_config.go
+++ b/pkg/types/operator_config.go
@@ -13,39 +13,6 @@ const (
 	LocalKeystoreSigner SignerType = "local_keystore"
 )
 
-type OperatorConfig struct {
-	Operator                      eigensdkTypes.Operator `yaml:"operator"`
-	ELSlasherAddress              string                 `yaml:"el_slasher_address"`
-	BlsPublicKeyCompendiumAddress string                 `yaml:"bls_public_key_compendium_address"`
-	EthRPCUrl                     string                 `yaml:"eth_rpc_url"`
-	PrivateKeyStorePath           string                 `yaml:"private_key_store_path"`
-	SignerType                    SignerType             `yaml:"signer_type"`
-	BlsPrivateKeyStorePath        string                 `yaml:"bls_private_key_store_path"`
-	ChainId                       big.Int                `yaml:"chain_id"`
-}
-
-func (config OperatorConfig) MarshalYAML() (interface{}, error) {
-	return struct {
-		Operator                      eigensdkTypes.Operator `yaml:"operator"`
-		ELSlasherAddress              string                 `yaml:"el_slasher_address"`
-		BlsPublicKeyCompendiumAddress string                 `yaml:"bls_public_key_compendium_address"`
-		EthRPCUrl                     string                 `yaml:"eth_rpc_url"`
-		PrivateKeyStorePath           string                 `yaml:"private_key_store_path"`
-		SignerType                    SignerType             `yaml:"signer_type"`
-		BlsPrivateKeyStorePath        string                 `yaml:"bls_private_key_store_path"`
-		ChainID                       int64                  `yaml:"chain_id"`
-	}{
-		Operator:                      config.Operator,
-		ELSlasherAddress:              config.ELSlasherAddress,
-		BlsPublicKeyCompendiumAddress: config.BlsPublicKeyCompendiumAddress,
-		EthRPCUrl:                     config.EthRPCUrl,
-		PrivateKeyStorePath:           config.PrivateKeyStorePath,
-		SignerType:                    config.SignerType,
-		BlsPrivateKeyStorePath:        config.BlsPrivateKeyStorePath,
-		ChainID:                       config.ChainId.Int64(),
-	}, nil
-}
-
 type OperatorConfigNew struct {
 	Operator                   eigensdkTypes.Operator `yaml:"operator"`
 	ELDelegationManagerAddress string                 `yaml:"el_delegation_manager_address"`


### PR DESCRIPTION
Fixes # .

### Motivation
It's been 2 months that we added config migration. almost everyone on holesky and mainnet would use new config so removing old config and migration logic

### Solution
<!--
What is the solution here from a high level. What are the key technical decisions and why were they made?
-->

### Open questions
<!--
(optional) Any open questions or feedback on design desired?
-->