### PR TITLE
add support for fireblocks wallet

### DIFF
--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -192,6 +192,9 @@ func getWallet(
 			cfg.FireblocksConfig.VaultAccountName,
 			logger,
 		)
+		if err != nil {
+			return nil, common.Address{}, err
+		}
 		sender, err = keyWallet.SenderAddress(context.Background())
 		if err != nil {
 			return nil, common.Address{}, err

--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -71,6 +71,7 @@ func RegisterCmd(p utils.Prompter) *cli.Command {
 			}
 
 			keyWallet, sender, err := getWallet(operatorCfg, ethClient, p, logger)
+			fmt.Println("sender: ", sender)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -9,24 +9,23 @@ import (
 	"strings"
 	"time"
 
-	eigensdkTypes "github.com/Layr-Labs/eigensdk-go/types"
-	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
-
-	"github.com/Layr-Labs/eigensdk-go/chainio/clients/fireblocks"
-
-	"github.com/Layr-Labs/eigensdk-go/chainio/txmgr"
-	"github.com/Layr-Labs/eigensdk-go/signerv2"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
-
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/types"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 
 	elContracts "github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/fireblocks"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/wallet"
+	"github.com/Layr-Labs/eigensdk-go/chainio/txmgr"
 	eigensdkLogger "github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/metrics"
+	"github.com/Layr-Labs/eigensdk-go/signerv2"
+	eigensdkTypes "github.com/Layr-Labs/eigensdk-go/types"
+	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -179,7 +179,7 @@ func getWallet(
 			cfg.FireblocksConfig.APIKey,
 			[]byte(cfg.FireblocksConfig.SecretKey),
 			cfg.FireblocksConfig.BaseUrl,
-			3*time.Second,
+			time.Duration(cfg.FireblocksConfig.Timeout)*time.Second,
 			logger,
 		)
 		if err != nil {

--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -139,7 +139,6 @@ func getWallet(
 	logger eigensdkLogger.Logger,
 ) (wallet.Wallet, common.Address, error) {
 	var keyWallet wallet.Wallet
-	var sender common.Address
 	if cfg.SignerType == types.LocalKeystoreSigner {
 		// Check if input is available in the pipe and read the password from it
 		ecdsaPassword, readFromPipe := utils.GetStdInPassword()
@@ -176,6 +175,7 @@ func getWallet(
 		if err != nil {
 			return nil, common.Address{}, err
 		}
+		return keyWallet, sender, nil
 	} else if cfg.SignerType == types.FireBlocksSigner {
 		fireblocksClient, err := fireblocks.NewClient(
 			cfg.FireblocksConfig.APIKey,
@@ -196,15 +196,14 @@ func getWallet(
 		if err != nil {
 			return nil, common.Address{}, err
 		}
-		sender, err = keyWallet.SenderAddress(context.Background())
+		sender, err := keyWallet.SenderAddress(context.Background())
 		if err != nil {
 			return nil, common.Address{}, err
 		}
+		return keyWallet, sender, nil
 	} else {
 		return nil, common.Address{}, fmt.Errorf("%s signer is not supported", cfg.SignerType)
 	}
-
-	return keyWallet, sender, nil
 }
 
 // expandTilde replaces the tilde (~) in the path with the home directory.

--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -71,7 +71,6 @@ func RegisterCmd(p utils.Prompter) *cli.Command {
 			}
 
 			keyWallet, sender, err := getWallet(operatorCfg, ethClient, p, logger)
-			fmt.Println("sender: ", sender)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/update.go
+++ b/pkg/operator/update.go
@@ -57,7 +57,6 @@ func UpdateCmd(p utils.Prompter) *cli.Command {
 			}
 
 			keyWallet, sender, err := getWallet(operatorCfg, ethClient, p, logger)
-			fmt.Println("sender: ", sender)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/update.go
+++ b/pkg/operator/update.go
@@ -40,6 +40,12 @@ func UpdateCmd(p utils.Prompter) *cli.Command {
 				return err
 			}
 
+			fmt.Printf(
+				"\r%s Operator configuration file validated successfully %s\n",
+				utils.EmojiCheckMark,
+				operatorCfg.Operator.Address,
+			)
+
 			logger, err := eigensdkLogger.NewZapLogger(eigensdkLogger.Development)
 			if err != nil {
 				return err
@@ -51,6 +57,7 @@ func UpdateCmd(p utils.Prompter) *cli.Command {
 			}
 
 			keyWallet, sender, err := getWallet(operatorCfg, ethClient, p, logger)
+			fmt.Println("sender: ", sender)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/update.go
+++ b/pkg/operator/update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/metrics"
 
 	"github.com/ethereum/go-ethereum/common"
-	
+
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/operator/update.go
+++ b/pkg/operator/update.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
+
 	elContracts "github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/eth"
 	"github.com/Layr-Labs/eigensdk-go/chainio/txmgr"
 	eigensdkLogger "github.com/Layr-Labs/eigensdk-go/logging"
 	"github.com/Layr-Labs/eigensdk-go/metrics"
+
 	"github.com/ethereum/go-ethereum/common"
+	
 	"github.com/urfave/cli/v2"
 )
 

--- a/pkg/types/operator_config.go
+++ b/pkg/types/operator_config.go
@@ -19,6 +19,9 @@ type FireblocksConfig struct {
 	SecretKey        string `yaml:"secret_key"`
 	BaseUrl          string `yaml:"base_url"`
 	VaultAccountName string `yaml:"vault_account_name"`
+
+	// Timeout for API in seconds
+	Timeout int64 `yaml:"timeout"`
 }
 
 type OperatorConfigNew struct {

--- a/pkg/types/operator_config.go
+++ b/pkg/types/operator_config.go
@@ -11,16 +11,25 @@ type SignerType string
 const (
 	PrivateKeySigner    SignerType = "private_key"
 	LocalKeystoreSigner SignerType = "local_keystore"
+	FireBlocksSigner    SignerType = "fireblocks"
 )
+
+type FireblocksConfig struct {
+	APIKey           string `yaml:"api_key"`
+	SecretKey        string `yaml:"secret_key"`
+	BaseUrl          string `yaml:"base_url"`
+	VaultAccountName string `yaml:"vault_account_name"`
+}
 
 type OperatorConfigNew struct {
 	Operator                   eigensdkTypes.Operator `yaml:"operator"`
 	ELDelegationManagerAddress string                 `yaml:"el_delegation_manager_address"`
 	ELAVSDirectoryAddress      string
-	EthRPCUrl                  string     `yaml:"eth_rpc_url"`
-	PrivateKeyStorePath        string     `yaml:"private_key_store_path"`
-	SignerType                 SignerType `yaml:"signer_type"`
-	ChainId                    big.Int    `yaml:"chain_id"`
+	EthRPCUrl                  string           `yaml:"eth_rpc_url"`
+	PrivateKeyStorePath        string           `yaml:"private_key_store_path"`
+	SignerType                 SignerType       `yaml:"signer_type"`
+	ChainId                    big.Int          `yaml:"chain_id"`
+	FireblocksConfig           FireblocksConfig `yaml:"fireblocks"`
 }
 
 func (config OperatorConfigNew) MarshalYAML() (interface{}, error) {


### PR DESCRIPTION
Fixes # .

### What Changed?

- Add support for fireblocks wallet signer
- The yaml file just takes the secret value directly. Will support AWS KMS in subsequent PR.

