### PR TITLE
refactor signer config and use that in wallet

### DIFF
--- a/pkg/operator/register.go
+++ b/pkg/operator/register.go
@@ -60,7 +60,14 @@ func RegisterCmd(p utils.Prompter) *cli.Command {
 				return err
 			}
 
-			keyWallet, sender, err := getWallet(operatorCfg, ethClient, p, logger)
+			keyWallet, sender, err := getWallet(
+				operatorCfg.SignerConfig,
+				operatorCfg.Operator.Address,
+				ethClient,
+				p,
+				operatorCfg.ChainId,
+				logger,
+			)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/setclaimer.go
+++ b/pkg/operator/setclaimer.go
@@ -54,7 +54,14 @@ Set the rewards claimer address for the operator.
 				return err
 			}
 
-			keyWallet, sender, err := getWallet(operatorCfg, ethClient, p, logger)
+			keyWallet, sender, err := getWallet(
+				operatorCfg.SignerConfig,
+				operatorCfg.Operator.Address,
+				ethClient,
+				p,
+				operatorCfg.ChainId,
+				logger,
+			)
 			if err != nil {
 				return err
 			}

--- a/pkg/operator/update.go
+++ b/pkg/operator/update.go
@@ -62,7 +62,14 @@ func UpdateCmd(p utils.Prompter) *cli.Command {
 				return err
 			}
 
-			keyWallet, sender, err := getWallet(operatorCfg, ethClient, p, logger)
+			keyWallet, sender, err := getWallet(
+				operatorCfg.SignerConfig,
+				operatorCfg.Operator.Address,
+				ethClient,
+				p,
+				operatorCfg.ChainId,
+				logger,
+			)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes # .

### What Changed?
- Refactored `getWallet` so it can be used called with `SignerConfig` and not dependent on `operatorConfig`
