### PR TITLE
fix: do not fail if no signer is provided when there's no broadcast flag

### DIFF
--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -289,7 +289,8 @@ func readAndValidateClaimConfig(cCtx *cli.Context, logger logging.Logger) (*Clai
 	// Get SignerConfig
 	signerConfig, err := common.GetSignerConfig(cCtx, logger)
 	if err != nil {
-		return nil, err
+		// We don't want to throw error since people can still use it to generate the claim
+		logger.Debugf("Failed to get signer config: %s", err)
 	}
 
 	return &ClaimConfig{

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -290,6 +290,7 @@ func readAndValidateClaimConfig(cCtx *cli.Context, logger logging.Logger) (*Clai
 	signerConfig, err := common.GetSignerConfig(cCtx, logger)
 	if err != nil {
 		// We don't want to throw error since people can still use it to generate the claim
+		// without broadcasting it
 		logger.Debugf("Failed to get signer config: %s", err)
 	}
 


### PR DESCRIPTION
Fixes # .

### What Changed?
- Fix bug when no broadcast and no signer details provided
