### PR TITLE
feat: claim rewards from last active root

### DIFF
--- a/pkg/rewards/README.md
+++ b/pkg/rewards/README.md
@@ -4,14 +4,14 @@
 ```bash
 eigenlayer rewards claim --help
 NAME:
-   eigenlayer rewards claim - Claim rewards for the operator
+   eigenlayer rewards claim - Claim rewards for any earner
 
 USAGE:
    eigenlayer rewards claim [command options]
 
 OPTIONS:
    --broadcast, -b                                      Use this flag to broadcast the transaction (default: false) [$BROADCAST]
-   --claim-timestamp value, -c value                    Specify the timestamp. Only 'latest' is supported (default: "latest") [$CLAIM_TIMESTAMP]
+   --claim-timestamp value, -c value                    Specify the timestamp. Only 'latest' and 'latest_active' are supported (default: "latest") [$CLAIM_TIMESTAMP]
    --earner-address value, --ea value                   Address of the earner [$REWARDS_EARNER_ADDRESS]
    --ecdsa-private-key value, -e value                  ECDSA private key hex to send transaction [$ECDSA_PRIVATE_KEY]
    --environment value, --env value                     Environment to use. Currently supports 'preprod' ,'testnet' and 'prod'. If not provided, it will be inferred based on network [$ENVIRONMENT]

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -296,8 +296,7 @@ func getClaimDistributionRoot(
 }
 
 // getLatestActivePostedRoot returns the latest active posted root by sorting the roots by the latest calculated end
-// timestamp
-// in descending order and checking the latest timestamp which activated before the current time
+// timestamp in descending order and checking the latest timestamp which activated before the current time
 func getLatestActivePostedRoot(postedRoots []*proofDataFetcher.SubmittedRewardRoot) (string, uint32, error) {
 	// sort by latest calculated end timestamp
 	sort.Slice(postedRoots, func(i, j int) bool {

--- a/pkg/rewards/claim_test.go
+++ b/pkg/rewards/claim_test.go
@@ -4,10 +4,12 @@ import (
 	"flag"
 	"os"
 	"testing"
+	"time"
 
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/testutils"
+	"github.com/Layr-Labs/eigenlayer-rewards-proofs/pkg/proofDataFetcher"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/testutils"
 
 	"github.com/Layr-Labs/eigensdk-go/logging"
 
@@ -54,4 +56,82 @@ func TestReadAndValidateConfig_RecipientProvided(t *testing.T) {
 	assert.Equal(t, common.HexToAddress(recipientAddress), config.RecipientAddress)
 }
 
-func TestGetLatestActivePostedRoot
+func TestGetLatestActivePostedRoot(t *testing.T) {
+	now := time.Now().UTC()
+	var tests = []struct {
+		name                   string
+		postedRoots            []*proofDataFetcher.SubmittedRewardRoot
+		expectedRootIndex      uint32
+		rewardsTimestampString string
+	}{
+		{
+			name: "found an activated root before current time",
+			postedRoots: []*proofDataFetcher.SubmittedRewardRoot{
+				{
+					RootIndex:        1,
+					ActivatedAt:      now,
+					CalcEndTimestamp: now.Add(-24 * time.Hour),
+				},
+				{
+					RootIndex:        2,
+					ActivatedAt:      now.Add(-2 * time.Hour),
+					CalcEndTimestamp: now.Add(-48 * time.Hour),
+				},
+				{
+					RootIndex:        3,
+					ActivatedAt:      now.Add(1 * time.Hour),
+					CalcEndTimestamp: now,
+				},
+			},
+			expectedRootIndex:      1,
+			rewardsTimestampString: now.Add(-24 * time.Hour).Format(time.DateOnly),
+		},
+		{
+			name: "found no activated root before current time",
+			postedRoots: []*proofDataFetcher.SubmittedRewardRoot{
+				{
+					RootIndex:        3,
+					ActivatedAt:      now.Add(1 * time.Hour),
+					CalcEndTimestamp: now,
+				},
+				{
+					RootIndex:        4,
+					ActivatedAt:      now.Add(2 * time.Hour),
+					CalcEndTimestamp: now.Add(3 * time.Hour),
+				},
+			},
+			expectedRootIndex: 0,
+		},
+		{
+			name: "found an activated root before current time 2",
+			postedRoots: []*proofDataFetcher.SubmittedRewardRoot{
+				{
+					RootIndex:        2,
+					ActivatedAt:      now.Add(-2 * time.Hour),
+					CalcEndTimestamp: now.Add(-24 * time.Hour),
+				},
+				{
+					RootIndex:        3,
+					ActivatedAt:      now.Add(1 * time.Hour),
+					CalcEndTimestamp: now.Add(-48 * time.Hour),
+				},
+			},
+			expectedRootIndex:      2,
+			rewardsTimestampString: now.Add(-24 * time.Hour).Format(time.DateOnly),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualRewardTimeString, actualRootIndex, err := getLatestActivePostedRoot(tt.postedRoots)
+			if tt.expectedRootIndex == 0 {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.rewardsTimestampString, actualRewardTimeString)
+			}
+			assert.Equal(t, tt.expectedRootIndex, actualRootIndex)
+
+		})
+	}
+}

--- a/pkg/rewards/claim_test.go
+++ b/pkg/rewards/claim_test.go
@@ -53,3 +53,5 @@ func TestReadAndValidateConfig_RecipientProvided(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, common.HexToAddress(recipientAddress), config.RecipientAddress)
 }
+
+func TestGetLatestActivePostedRoot

--- a/pkg/rewards/flags.go
+++ b/pkg/rewards/flags.go
@@ -21,7 +21,7 @@ var (
 	ClaimTimestampFlag = cli.StringFlag{
 		Name:    "claim-timestamp",
 		Aliases: []string{"c"},
-		Usage:   "Specify the timestamp. Only 'latest' is supported",
+		Usage:   "Specify the timestamp. Only 'latest' and 'latest_active' are supported",
 		Value:   "latest",
 		EnvVars: []string{"CLAIM_TIMESTAMP"},
 	}


### PR DESCRIPTION
Fixes # .

### What Changed?
- Add support for an user to claim rewards at the latest active root instead of latest available root since latest available root can be inactive
