### PR TITLE
chore: default claims to latest active timestamp

### DIFF
--- a/pkg/rewards/flags.go
+++ b/pkg/rewards/flags.go
@@ -21,8 +21,8 @@ var (
 	ClaimTimestampFlag = cli.StringFlag{
 		Name:    "claim-timestamp",
 		Aliases: []string{"c"},
-		Usage:   "Specify the timestamp. Only 'latest' and 'latest_active' are supported",
-		Value:   "latest",
+		Usage:   "Specify the timestamp. Only 'latest' and 'latest_active' are supported. 'latest' can be an inactive root which you can't claim yet.",
+		Value:   "latest_active",
 		EnvVars: []string{"CLAIM_TIMESTAMP"},
 	}
 


### PR DESCRIPTION
Fixes # .

### What Changed?
- default claim to latest active root
