### PR TITLE
chore: trim `0x` from private key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 include .env
 
 GO_LINES_IGNORED_DIRS=
-GO_PACKAGES=./pkg/... ./cmd/...
+GO_PACKAGES=./pkg/... ./cmd/... ./internal/...
 GO_FOLDERS=$(shell echo ${GO_PACKAGES} | sed -e "s/\.\///g" | sed -e "s/\/\.\.\.//g")
 
 help:

--- a/internal/versionupdate/check_version_update.go
+++ b/internal/versionupdate/check_version_update.go
@@ -67,7 +67,9 @@ func Check(currentVersion string) {
 		fmt.Println()
 		fmt.Printf("There is a new version (%s) for this library available.\n", greenVersion)
 		fmt.Printf("Your current running verison is (%s).\n", yellowOldVersion)
-		fmt.Println("Please update (https://github.com/Layr-Labs/eigenlayer-cli#install-eigenlayer-cli-using-a-binary) to get latest features and bug fixes.")
+		fmt.Println(
+			"Please update (https://github.com/Layr-Labs/eigenlayer-cli#install-eigenlayer-cli-using-a-binary) to get latest features and bug fixes.",
+		)
 		fmt.Println()
 	}
 }

--- a/pkg/internal/common/helper.go
+++ b/pkg/internal/common/helper.go
@@ -342,7 +342,7 @@ func GetSignerConfig(cCtx *cli.Context, logger eigensdkLogger.Logger) (*types.Si
 	ecdsaPrivateKeyString := cCtx.String(flags.EcdsaPrivateKeyFlag.Name)
 	if !IsEmptyString(ecdsaPrivateKeyString) {
 		logger.Debug("Using private key signer")
-		pk, err := crypto.HexToECDSA(ecdsaPrivateKeyString)
+		pk, err := crypto.HexToECDSA(Trim0x(ecdsaPrivateKeyString))
 		if err != nil {
 			return nil, err
 		}
@@ -437,4 +437,8 @@ func GetNoSendTxOpts(from common.Address) *bind.TransactOpts {
 		Signer: noopSigner,
 		NoSend: true,
 	}
+}
+
+func Trim0x(s string) string {
+	return strings.TrimPrefix(s, "0x")
 }

--- a/pkg/keys/import.go
+++ b/pkg/keys/import.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
-	"strings"
 
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
-
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
+
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/urfave/cli/v2"
@@ -65,7 +65,7 @@ This command will import keys in $HOME/.eigenlayer/operator_keys/ location
 
 			switch keyType {
 			case KeyTypeECDSA:
-				privateKey = strings.TrimPrefix(privateKey, "0x")
+				privateKey = common.Trim0x(privateKey)
 				privateKeyPair, err := crypto.HexToECDSA(privateKey)
 				if err != nil {
 					return err
@@ -86,7 +86,7 @@ This command will import keys in $HOME/.eigenlayer/operator_keys/ location
 					// Try to parse as hex
 					fmt.Println("Importing from hex")
 					z := new(big.Int)
-					privateKey = strings.TrimPrefix(privateKey, "0x")
+					privateKey = common.Trim0x(privateKey)
 					_, ok := z.SetString(privateKey, 16)
 					if !ok {
 						return ErrInvalidHexPrivateKey

--- a/pkg/keys/import_test.go
+++ b/pkg/keys/import_test.go
@@ -7,15 +7,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-
-	"github.com/urfave/cli/v2"
 
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	prompterMock "github.com/Layr-Labs/eigenlayer-cli/pkg/utils/mocks"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 )
 
@@ -202,7 +202,7 @@ func TestImportCmd(t *testing.T) {
 				if tt.args[1] == KeyTypeECDSA {
 					key, err := GetECDSAPrivateKey(tt.keyPath, "")
 					assert.NoError(t, err)
-					assert.Equal(t, strings.Trim(tt.args[3], "0x"), hex.EncodeToString(key.D.Bytes()))
+					assert.Equal(t, common.Trim0x(tt.args[3]), hex.EncodeToString(key.D.Bytes()))
 				} else if tt.args[1] == KeyTypeBLS {
 					key, err := bls.ReadPrivateKeyFromFile(tt.keyPath, "")
 					assert.NoError(t, err)

--- a/pkg/operator/keys/import.go
+++ b/pkg/operator/keys/import.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"math/big"
 	"regexp"
-	"strings"
 
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
-
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
+
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/urfave/cli/v2"
@@ -65,7 +65,7 @@ This command will import keys in $HOME/.eigenlayer/operator_keys/ location
 
 			switch keyType {
 			case KeyTypeECDSA:
-				privateKey = strings.TrimPrefix(privateKey, "0x")
+				privateKey = common.Trim0x(privateKey)
 				privateKeyPair, err := crypto.HexToECDSA(privateKey)
 				if err != nil {
 					return err
@@ -86,7 +86,7 @@ This command will import keys in $HOME/.eigenlayer/operator_keys/ location
 					// Try to parse as hex
 					fmt.Println("Importing from hex")
 					z := new(big.Int)
-					privateKey = strings.TrimPrefix(privateKey, "0x")
+					privateKey = common.Trim0x(privateKey)
 					_, ok := z.SetString(privateKey, 16)
 					if !ok {
 						return ErrInvalidHexPrivateKey

--- a/pkg/operator/keys/import_test.go
+++ b/pkg/operator/keys/import_test.go
@@ -7,15 +7,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
-
-	"github.com/urfave/cli/v2"
 
 	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	prompterMock "github.com/Layr-Labs/eigenlayer-cli/pkg/utils/mocks"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
 	"go.uber.org/mock/gomock"
 )
 
@@ -203,7 +203,7 @@ func TestImportCmd(t *testing.T) {
 				if tt.args[1] == KeyTypeECDSA {
 					key, err := GetECDSAPrivateKey(tt.keyPath, "")
 					assert.NoError(t, err)
-					assert.Equal(t, strings.Trim(tt.args[3], "0x"), hex.EncodeToString(key.D.Bytes()))
+					assert.Equal(t, common.Trim0x(tt.args[3]), hex.EncodeToString(key.D.Bytes()))
 				} else if tt.args[1] == KeyTypeBLS {
 					key, err := bls.ReadPrivateKeyFromFile(tt.keyPath, "")
 					assert.NoError(t, err)


### PR DESCRIPTION
Fixes # .

### What Changed?
- Trim `0x` from private key so any format is acceptable.
- Some formatting related changes
