### PR TITLE
fix: add claimer address flag when claimer is not earner for claim method

### DIFF
--- a/pkg/internal/common/helper.go
+++ b/pkg/internal/common/helper.go
@@ -419,11 +419,16 @@ func IsEmptyString(s string) bool {
 
 func GetLogger(cCtx *cli.Context) eigensdkLogger.Logger {
 	verbose := cCtx.Bool(flags.VerboseFlag.Name)
-	logLevel := slog.LevelInfo
-	if verbose {
-		logLevel = slog.LevelDebug
+	loggerOptions := &eigensdkLogger.SLoggerOptions{
+		Level: slog.LevelInfo,
 	}
-	logger := eigensdkLogger.NewTextSLogger(os.Stdout, &eigensdkLogger.SLoggerOptions{Level: logLevel})
+	if verbose {
+		loggerOptions = &eigensdkLogger.SLoggerOptions{
+			Level:     slog.LevelDebug,
+			AddSource: true,
+		}
+	}
+	logger := eigensdkLogger.NewTextSLogger(os.Stdout, loggerOptions)
 	return logger
 }
 

--- a/pkg/rewards/README.md
+++ b/pkg/rewards/README.md
@@ -11,7 +11,8 @@ USAGE:
 
 OPTIONS:
    --broadcast, -b                                      Use this flag to broadcast the transaction (default: false) [$BROADCAST]
-   --claim-timestamp value, -c value                    Specify the timestamp. Only 'latest' and 'latest_active' are supported (default: "latest") [$CLAIM_TIMESTAMP]
+   --claim-timestamp value, -c value                    Specify the timestamp. Only 'latest' and 'latest_active' are supported. 'latest' can be an inactive root which you can't claim yet. (default: "latest_active") [$CLAIM_TIMESTAMP]
+   --claimer-address value, -a value                    Address of the claimer [$REWARDS_CLAIMER_ADDRESS]
    --earner-address value, --ea value                   Address of the earner [$REWARDS_EARNER_ADDRESS]
    --ecdsa-private-key value, -e value                  ECDSA private key hex to send transaction [$ECDSA_PRIVATE_KEY]
    --environment value, --env value                     Environment to use. Currently supports 'preprod' ,'testnet' and 'prod'. If not provided, it will be inferred based on network [$ENVIRONMENT]
@@ -78,7 +79,7 @@ DESCRIPTION:
 
 OPTIONS:
    --broadcast, -b                                      Use this flag to broadcast the transaction (default: false) [$BROADCAST]
-   --claimer-address value, -a value                    Address of the claimer [$NODE_OPERATOR_CLAIMER_ADDRESS]
+   --claimer-address value, -a value                    Address of the claimer [$REWARDS_CLAIMER_ADDRESS]
    --earner-address value, --ea value                   Address of the earner [$REWARDS_EARNER_ADDRESS]
    --ecdsa-private-key value, -e value                  ECDSA private key hex to send transaction [$ECDSA_PRIVATE_KEY]
    --eth-rpc-url value, -r value                        URL of the Ethereum RPC [$ETH_RPC_URL]

--- a/pkg/rewards/flags.go
+++ b/pkg/rewards/flags.go
@@ -51,8 +51,8 @@ var (
 		Name:     "claimer-address",
 		Aliases:  []string{"a"},
 		Usage:    "Address of the claimer",
-		Required: true,
-		EnvVars:  []string{"NODE_OPERATOR_CLAIMER_ADDRESS"},
+		Required: false,
+		EnvVars:  []string{"REWARDS_CLAIMER_ADDRESS"},
 	}
 
 	EarnerAddressFlag = cli.StringFlag{

--- a/pkg/rewards/setclaimer.go
+++ b/pkg/rewards/setclaimer.go
@@ -131,6 +131,10 @@ func SetClaimer(cCtx *cli.Context, p utils.Prompter) error {
 		return nil
 	}
 
+	if config.SignerConfig == nil {
+		return fmt.Errorf("signer config is required to broadcast the transaction")
+	}
+
 	keyWallet, sender, err := common.GetWallet(
 		*config.SignerConfig,
 		config.EarnerAddress.Hex(),
@@ -191,6 +195,10 @@ func readAndValidateSetClaimerConfig(cCtx *cli.Context, logger logging.Logger) (
 	earnerAddress := gethcommon.HexToAddress(cCtx.String(EarnerAddressFlag.Name))
 	broadcast := cCtx.Bool(flags.BroadcastFlag.Name)
 	claimerAddress := cCtx.String(ClaimerAddressFlag.Name)
+	if common.IsEmptyString(claimerAddress) {
+		return nil, fmt.Errorf("claimer address is required")
+	}
+
 	rewardsCoordinatorAddress := cCtx.String(RewardsCoordinatorAddressFlag.Name)
 	var err error
 	if common.IsEmptyString(rewardsCoordinatorAddress) {


### PR DESCRIPTION
Fixes # .

### What Changed?
- There is a bug where we can't set claimer address in non broadcast mode when earner has set a new claimer address. This PR adds that and fixes it. 
- In the broadcast mode, it depends on the signer so that path was working
- Some debug logging improvements 
