### PR TITLE
fix: hardcode gas limit for smart contract claimer

### DIFF
--- a/pkg/internal/common/eth.go
+++ b/pkg/internal/common/eth.go
@@ -24,11 +24,11 @@ type TxFeeDetails struct {
 }
 
 func (t *TxFeeDetails) Print() {
-	message := strings.Repeat("-", 25) + " Gas Fee Details " + strings.Repeat("-", 25)
+	message := strings.Repeat("-", 30) + " Gas Fee Details " + strings.Repeat("-", 30)
 	fmt.Println(message)
 	fmt.Printf("Gas Tip Cap: %0.9f Gwei\n", t.GasTipCapGwei)
 	fmt.Printf("Gas Fee Cap: %0.9f Gwei\n", t.GasFeeCapGwei)
-	fmt.Printf("Gas Limit: %d\n", t.GasLimit)
+	fmt.Printf("Gas Limit: %d (If claimer is a smart contract, this value is hardcoded)\n", t.GasLimit)
 	fmt.Printf("Approximate Max Cost of transaction: %0.12f ETH\n", t.CostInEth)
 	fmt.Println(strings.Repeat("-", len(message)))
 }

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -205,8 +205,9 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 		}
 
 		// If claimer is a smart contract, we can't estimate gas using geth
-		// since it doesn't support estimate gas for calling smart contract
-		// from smart contract. So we set a default gas limit.
+		// since balance of contract can be 0, as it can be called by an EOA
+		// to claim. So we hardcode the gas limit to 150_000 so that we can
+		// create unsigned tx without gas limit estimation from contract bindings
 		code, err := ethClient.CodeAt(ctx, config.ClaimerAddress, nil)
 		if err != nil {
 			return eigenSdkUtils.WrapError("failed to get code at address", err)


### PR DESCRIPTION
Fixes # .

### What Changed?
<!-- Describe the changes you made in this PR -->

If the claimer is smart contract, we disable the estimation of `gasLimit` as the contract might not have it's own balance since it can be called by EOA.  
So we hardcode gas limit in  non-broadcast mode so that we can generate unsigned transaction.
