### PR TITLE
ELO-335 -- lowering claim tokenAddresses to optional; using distribution to only query claimable tokens.

### DIFF
--- a/pkg/rewards/flags.go
+++ b/pkg/rewards/flags.go
@@ -6,9 +6,9 @@ var (
 	TokenAddressesFlag = cli.StringFlag{
 		Name:     "token-addresses",
 		Aliases:  []string{"t"},
-		Usage:    "Specify the addresses of the tokens to claim. Comma separated list of addresses",
+		Usage:    "Specify the addresses of the tokens to claim. Comma separated list of addresses. Omit to claim all rewards.",
 		EnvVars:  []string{"TOKEN_ADDRESSES"},
-		Required: true,
+		Required: false,
 	}
 
 	RewardsCoordinatorAddressFlag = cli.StringFlag{


### PR DESCRIPTION
### Motivation
https://github.com/Layr-Labs/eigenlayer-cli/issues/220

Prior to this change, users trying to claim rewards needed to know the token addresses they intend to claim rewards for. When no rewards are present, they receive errors and logs indicating the issue. They must iteratively remove token addresses from their input until they've reduced the set to addresses with claimable rewards. Also, they are _required_ to know the token address of the rewards they want to claim. Users need a mechanism in the CLI to address these pain points.

### What Changed?
This change brings two behavioral changes to the API. 
1. When no `tokenAddresses` is provided, or it's empty, the CLI uses the public rewards distribution to claim all available rewards.
2. When `tokenAddresses` are provided, the CLI uses the public rewards distribution to claim rewards only for the token addresses with claimable rewards.

### Testing
Added unit test coverage.
