### PR TITLE
Clarify Active Root

### DIFF
--- a/pkg/rewards/README.md
+++ b/pkg/rewards/README.md
@@ -118,7 +118,7 @@ For testnet, remove the `--rewards-coordinator-address` flag and binary will aut
 ```bash
 eigenlayer rewards show --help
 NAME:
-   eigenlayer rewards show - Show rewards for an address
+   eigenlayer rewards show - Show rewards for an address against the latest `active` `DistributionRoot` posted on-chain by the rewards updater.
 
 USAGE:
    show


### PR DESCRIPTION
Fixes question from customer (via Slack)

### What Changed?
<!-- Describe the changes you made in this PR -->
Adding clarification that the `show` subcommand works against the active root by default.