### PR TITLE
Update show.go

### DIFF
--- a/pkg/operator/allocations/show.go
+++ b/pkg/operator/allocations/show.go
@@ -278,7 +278,11 @@ func getSharesFromMagnitude(totalScaledShare *big.Int, magnitude uint64) (*big.I
 	 * shares = totalScaledShare * magnitude / PrecisionFactor
 	 * percentageShares = (shares / totalScaledShare) * 100
 	 */
-
+	// Check for zero magnitude or totalScaledShare to avoid divide-by-zero errors
+	if magnitude == 0 || totalScaledShare.Cmp(big.NewInt(0)) == 0 {
+		return big.NewInt(0), big.NewFloat(0)
+	}
+	
 	slashableMagBigInt := big.NewInt(1)
 	slashableMagBigInt = slashableMagBigInt.SetUint64(magnitude)
 


### PR DESCRIPTION
fix divide by zero errors like the one below
```Oct 14 14:14:50.283 DBG allocations/show.go:87 Allocatable magnitude for strategy 0x..... : 0
panic: division of zero by zero or infinity by infinity

Fixes # .

### What Changed?
Added a check to ensure we don't divide by 0, tested and verified with no panics after this patch.