### PR TITLE
fix: bug in delegation approval when no signer provided

### DIFF
--- a/pkg/operator/get_delegation_approval.go
+++ b/pkg/operator/get_delegation_approval.go
@@ -194,7 +194,12 @@ func getApprovalConfig(cCtx *cli.Context) (*ApprovalConfig, error) {
 	privateKeyHex := cCtx.String(flags.EcdsaPrivateKeyFlag.Name)
 	keystoreFilePath := cCtx.String(flags.PathToKeyStoreFlag.Name)
 	if privateKeyHex == "" && keystoreFilePath == "" {
-		return nil, fmt.Errorf("either private key or keystore file path is required. other signer not supported")
+		return &ApprovalConfig{
+			OperatorConfigFilePath: configurationFilePath,
+			StakerAddress:          stakerAddress,
+			Expiry:                 expirySeconds,
+			SignerConfig:           types.SignerConfig{},
+		}, nil
 	}
 
 	if privateKeyHex != "" {


### PR DESCRIPTION
Fixes # .

### What Changed?
- When no signer is provided, the command fails. But we want to generate salt for the approver to sign by themselves. This fixes it. 
