### PR TITLE
Fix panic: runtime error on SetClaimer

### DIFF
--- a/pkg/rewards/setclaimer.go
+++ b/pkg/rewards/setclaimer.go
@@ -80,6 +80,9 @@ func SetClaimer(cCtx *cli.Context, p utils.Prompter) error {
 
 		noSendTxOpts := common.GetNoSendTxOpts(config.EarnerAddress)
 		unsignedTx, err := contractBindings.RewardsCoordinator.SetClaimerFor(noSendTxOpts, config.ClaimerAddress)
+		if err != nil {
+			return eigenSdkUtils.WrapError("failed to create unsigned tx", err)
+		}
 
 		if config.OutputType == string(common.OutputType_Calldata) {
 			if err != nil {


### PR DESCRIPTION
This fixes panic using SetClaimer when unhandled GetTxFeeDetails returns nil transaction instead of returning error.

Example of before fix:

```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1010a6d40]

goroutine 1 [running]:
github.com/ethereum/go-ethereum/core/types.(*Transaction).GasTipCap(0x0)
	/Users/aivaras/go/pkg/mod/github.com/ethereum/go-ethereum@v1.14.5/core/types/transaction.go:295 +0x30
github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common.GetTxFeeDetails(0x0)
	/Users/aivaras/projects/eigenlayer-cli/pkg/internal/common/eth.go:37 +0x24
...	
```

Fix would return more informative error like:

```failed to create unsigned tx: no contract code at given address``` 