### PR TITLE
feat: Rewards v2 batch claiming support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Layr-Labs/eigenlayer-contracts v0.3.2-mainnet-rewards
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.12
 	github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-5c11a259293e
-	github.com/Layr-Labs/eigensdk-go v0.1.13-0.20241023200243-565bb4438918
+	github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241121204729-7d2cd162ffe8
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/gnark-crypto v0.12.1
 	github.com/ethereum/go-ethereum v1.14.5

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-
 github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-5c11a259293e/go.mod h1:T7tYN8bTdca2pkMnz9G2+ZwXYWw5gWqQUIu4KLgC/vM=
 github.com/Layr-Labs/eigensdk-go v0.1.13-0.20241023200243-565bb4438918 h1:Itl141PoMFzq58ZTo4Nu/CyH+x8f4BH6OmBNhZ6Z2/I=
 github.com/Layr-Labs/eigensdk-go v0.1.13-0.20241023200243-565bb4438918/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
+github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241121204729-7d2cd162ffe8 h1:6wuVq+Elto+yF7bQ3QYqD2psxGXR3wcJh2koNcUjIQM=
+github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241121204729-7d2cd162ffe8/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=

--- a/pkg/internal/common/flags/general.go
+++ b/pkg/internal/common/flags/general.go
@@ -90,4 +90,11 @@ var (
 		EnvVars: []string{"EXPIRY"},
 		Value:   3600,
 	}
+
+	BatchClaimFile = cli.StringFlag{
+		Name:    "batchClaimFile",
+		Aliases: []string{"bcf"},
+		Usage:   "Input file for batch rewards claim",
+		EnvVars: []string{"BATCH_CLAIM_FILE"},
+	}
 )

--- a/pkg/internal/common/flags/general.go
+++ b/pkg/internal/common/flags/general.go
@@ -92,7 +92,7 @@ var (
 	}
 
 	BatchClaimFile = cli.StringFlag{
-		Name:    "batchClaimFile",
+		Name:    "batch-claim-file",
 		Aliases: []string{"bcf"},
 		Usage:   "Input file for batch rewards claim",
 		EnvVars: []string{"BATCH_CLAIM_FILE"},

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -115,7 +115,7 @@ func BatchClaim(cCtx *cli.Context, ethClient *ethclient.Client, elReader *elcont
 			tokenAddrs = append(tokenAddrs, gethcommon.HexToAddress(addr))
 		}
 
-		elClaim, _, _, err := claimHelper(config.ClaimTimestamp, ctx, elReader, logger, earnerAddr, df, tokenAddrs)
+		elClaim, _, _, err := claimHelper(ctx, config.ClaimTimestamp, elReader, logger, earnerAddr, df, tokenAddrs)
 
 		elClaims = append(elClaims, *elClaim)
 
@@ -157,8 +157,8 @@ func BatchClaim(cCtx *cli.Context, ethClient *ethclient.Client, elReader *elcont
 }
 
 func claimHelper(
-	claimTimestamp string,
 	ctx context.Context,
+	claimTimestamp string,
 	elReader *elcontracts.ChainReader,
 	logger logging.Logger,
 	earnerAddress gethcommon.Address,
@@ -260,7 +260,7 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 		return BatchClaim(cCtx, ethClient, elReader, df, config, p)
 	}
 
-	elClaim, claim, accounts, err := claimHelper(config.ClaimTimestamp, ctx, elReader, logger, config.EarnerAddress, df, config.TokenAddresses)
+	elClaim, claim, accounts, err := claimHelper(ctx, config.ClaimTimestamp, elReader, logger, config.EarnerAddress, df, config.TokenAddresses)
 
 	if err != nil {
 		return err

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -93,10 +93,8 @@ func batchClaim(
 	logger logging.Logger,
 	ethClient *ethclient.Client,
 	elReader *elcontracts.ChainReader,
-	df *httpProofDataFetcher.HttpProofDataFetcher,
 	config *ClaimConfig,
 	p utils.Prompter,
-	claimDate string,
 	rootIndex uint32,
 	proofData *proofDataFetcher.RewardProofData,
 ) error {
@@ -260,7 +258,7 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 	}
 
 	if config.BatchClaimFile != "" {
-		return batchClaim(ctx, logger, ethClient, elReader, df, config, p, claimDate, rootIndex, proofData)
+		return batchClaim(ctx, logger, ethClient, elReader, config, p, rootIndex, proofData)
 	}
 
 	elClaim, claim, account, err := generateClaimPayload(

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -372,33 +372,37 @@ func broadcastClaims(config *ClaimConfig,
 				fmt.Println(calldataHex)
 			}
 		} else if config.OutputType == string(common.OutputType_Json) {
-			solidityClaim := claimgen.FormatProofForSolidity((*accounts)[0].Root(), &(*claims)[0])
-			jsonData, err := json.MarshalIndent(solidityClaim, "", "  ")
-			if err != nil {
-				logger.Error("Error marshaling JSON:", err)
-				return err
-			}
-			if !common.IsEmptyString(config.Output) {
-				err = common.WriteToFile(jsonData, config.Output)
+			for idx, claim := range *claims {
+				solidityClaim := claimgen.FormatProofForSolidity((*accounts)[idx].Root(), &claim)
+				jsonData, err := json.MarshalIndent(solidityClaim, "", "  ")
 				if err != nil {
+					logger.Error("Error marshaling JSON:", err)
 					return err
 				}
-				logger.Infof("Claim written to file: %s", config.Output)
-			} else {
-				fmt.Println(string(jsonData))
-				fmt.Println()
-				fmt.Println("To write to a file, use the --output flag")
+				if !common.IsEmptyString(config.Output) {
+					err = common.WriteToFile(jsonData, config.Output)
+					if err != nil {
+						return err
+					}
+					logger.Infof("Claim written to file: %s", config.Output)
+				} else {
+					fmt.Println(string(jsonData))
+					fmt.Println()
+					fmt.Println("To write to a file, use the --output flag")
+				}
 			}
 		} else {
 			if !common.IsEmptyString(config.Output) {
 				fmt.Println("output file not supported for pretty output type")
 				fmt.Println()
 			}
-			solidityClaim := claimgen.FormatProofForSolidity((*accounts)[0].Root(), &(*claims)[0])
-			if !config.IsSilent {
-				fmt.Println("------- Claim generated -------")
+			for idx, claim := range *claims {
+				solidityClaim := claimgen.FormatProofForSolidity((*accounts)[idx].Root(), &claim)
+				if !config.IsSilent {
+					fmt.Println("------- Claim generated -------")
+				}
+				common.PrettyPrintStruct(*solidityClaim)
 			}
-			common.PrettyPrintStruct(*solidityClaim)
 			if !config.IsSilent {
 				fmt.Println("-------------------------------")
 				fmt.Println("To write to a file, use the --output flag")

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -197,10 +197,6 @@ func claimHelper(
 		return nil, nil, nil, eigenSdkUtils.WrapError("failed to generate claim proof for earner", err)
 	}
 
-	if err != nil {
-		return nil, nil, nil, eigenSdkUtils.WrapError("failed to generate claim proof for earner", err)
-	}
-
 	elClaim := rewardscoordinator.IRewardsCoordinatorRewardsMerkleClaim{
 		RootIndex:       claim.RootIndex,
 		EarnerIndex:     claim.EarnerIndex,

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -293,6 +293,9 @@ func broadcastClaims(
 	claims []contractrewardscoordinator.IRewardsCoordinatorRewardsMerkleClaim,
 	accounts []merkletree.MerkleTree,
 ) error {
+	if len(elClaims) == 0 {
+		return fmt.Errorf("at least one claim is required")
+	}
 	if config.Broadcast {
 		eLWriter, err := common.GetELWriter(
 			config.ClaimerAddress,

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -144,14 +144,15 @@ func BatchClaim(
 			tokenAddrs,
 		)
 
-		elClaims = append(elClaims, *elClaim)
-		claims = append(claims, *claim)
-		accounts = append(accounts, *account)
-
 		if err != nil {
 			logger.Errorf("Failed to process claim for earner %s: %v", earnerAddr.String(), err)
 			continue
 		}
+
+		elClaims = append(elClaims, *elClaim)
+		claims = append(claims, *claim)
+		accounts = append(accounts, *account)
+
 	}
 
 	err = broadcastClaims(config, ethClient, logger, p, ctx, &elClaims, &claims, &accounts)

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -145,7 +145,7 @@ func BatchClaim(
 		)
 
 		if err != nil {
-			logger.Errorf("Failed to process claim for earner %s: %v", earnerAddr.String(), err)
+			logger.Warnf("Failed to process claim for earner %s: %v", earnerAddr.String(), err)
 			continue
 		}
 

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -89,7 +89,8 @@ func getClaimFlags() []cli.Flag {
 }
 
 func BatchClaim(
-	cCtx *cli.Context,
+	ctx context.Context,
+	logger logging.Logger,
 	ethClient *ethclient.Client,
 	elReader *elcontracts.ChainReader,
 	df *httpProofDataFetcher.HttpProofDataFetcher,
@@ -99,8 +100,6 @@ func BatchClaim(
 	rootIndex uint32,
 	proofData *proofDataFetcher.RewardProofData,
 ) error {
-	ctx := cCtx.Context
-	logger := common.GetLogger(cCtx)
 
 	yamlFile, err := os.ReadFile(config.BatchClaimFile)
 	if err != nil {
@@ -261,7 +260,7 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 	}
 
 	if config.BatchClaimFile != "" {
-		return BatchClaim(cCtx, ethClient, elReader, df, config, p, claimDate, rootIndex, proofData)
+		return BatchClaim(ctx, logger, ethClient, elReader, df, config, p, claimDate, rootIndex, proofData)
 	}
 
 	elClaim, claim, account, err := generateClaimPayload(

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -283,7 +283,8 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 	return err
 }
 
-func broadcastClaims(config *ClaimConfig,
+func broadcastClaims(
+	config *ClaimConfig,
 	ethClient *ethclient.Client,
 	logger logging.Logger,
 	p utils.Prompter,

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -348,7 +348,7 @@ func broadcastClaims(
 			noSendTxOpts.GasLimit = 150_000
 		}
 		var unsignedTx *types.Transaction
-		if len(elClaims) > 0 {
+		if len(elClaims) > 1 {
 			unsignedTx, err = contractBindings.RewardsCoordinator.ProcessClaims(noSendTxOpts, elClaims, config.RecipientAddress)
 		} else {
 			unsignedTx, err = contractBindings.RewardsCoordinator.ProcessClaim(noSendTxOpts, elClaims[0], config.RecipientAddress)

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -236,7 +236,8 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 		elcontracts.Config{
 			RewardsCoordinatorAddress: config.RewardsCoordinatorAddress,
 		},
-		ethClient, logger,
+		ethClient,
+		logger,
 	)
 	if err != nil {
 		return eigenSdkUtils.WrapError("failed to create new reader from config", err)

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -86,7 +86,14 @@ func getClaimFlags() []cli.Flag {
 	return allFlags
 }
 
-func BatchClaim(cCtx *cli.Context, ethClient *ethclient.Client, elReader *elcontracts.ChainReader, df *httpProofDataFetcher.HttpProofDataFetcher, config *ClaimConfig, p utils.Prompter) error {
+func BatchClaim(
+	cCtx *cli.Context,
+	ethClient *ethclient.Client,
+	elReader *elcontracts.ChainReader,
+	df *httpProofDataFetcher.HttpProofDataFetcher,
+	config *ClaimConfig,
+	p utils.Prompter,
+) error {
 	ctx := cCtx.Context
 	logger := common.GetLogger(cCtx)
 
@@ -115,7 +122,15 @@ func BatchClaim(cCtx *cli.Context, ethClient *ethclient.Client, elReader *elcont
 			tokenAddrs = append(tokenAddrs, gethcommon.HexToAddress(addr))
 		}
 
-		elClaim, _, _, err := generateClaimPayload(ctx, config.ClaimTimestamp, elReader, logger, earnerAddr, df, tokenAddrs)
+		elClaim, _, _, err := generateClaimPayload(
+			ctx,
+			config.ClaimTimestamp,
+			elReader,
+			logger,
+			earnerAddr,
+			df,
+			tokenAddrs,
+		)
 
 		elClaims = append(elClaims, *elClaim)
 
@@ -260,7 +275,15 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 		return BatchClaim(cCtx, ethClient, elReader, df, config, p)
 	}
 
-	elClaim, claim, accounts, err := generateClaimPayload(ctx, config.ClaimTimestamp, elReader, logger, config.EarnerAddress, df, config.TokenAddresses)
+	elClaim, claim, accounts, err := generateClaimPayload(
+		ctx,
+		config.ClaimTimestamp,
+		elReader,
+		logger,
+		config.EarnerAddress,
+		df,
+		config.TokenAddresses,
+	)
 
 	if err != nil {
 		return err

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -210,7 +210,7 @@ func generateClaimPayload(
 		TokenLeaves:     convertClaimTokenLeaves(claim.TokenLeaves),
 	}
 
-	logger.Info("Validating claim proof...")
+	logger.Infof("Validating claim proof for earner %s...", earnerAddress)
 	ok, err := elReader.CheckClaim(ctx, elClaim)
 	if err != nil {
 		return nil, nil, nil, err
@@ -218,7 +218,7 @@ func generateClaimPayload(
 	if !ok {
 		return nil, nil, nil, errors.New("failed to validate claim")
 	}
-	logger.Info("Claim proof validated successfully")
+	logger.Infof("Claim proof for earner %s validated successfully", earnerAddress)
 
 	return &elClaim, claim, accounts, nil
 }

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -374,7 +374,6 @@ func broadcastClaims(
 				solidityClaim := claimgen.FormatProofForSolidity(accounts[idx].Root(), &claim)
 				jsonData, err := json.MarshalIndent(solidityClaim, "", "  ")
 				if err != nil {
-					logger.Error("Error marshaling JSON:", err)
 					return err
 				}
 				if !common.IsEmptyString(config.Output) {

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -118,8 +118,15 @@ func BatchClaim(
 		earnerAddr := gethcommon.HexToAddress(claimConfig.EarnerAddress)
 
 		var tokenAddrs []gethcommon.Address
-		for _, addr := range claimConfig.TokenAddresses {
-			tokenAddrs = append(tokenAddrs, gethcommon.HexToAddress(addr))
+
+		// Empty token addresses list will create a claim for all tokens claimable
+		// by the earner address.
+		if len(claimConfig.TokenAddresses) == 0 {
+			tokenAddrs = nil
+		} else {
+			for _, addr := range claimConfig.TokenAddresses {
+				tokenAddrs = append(tokenAddrs, gethcommon.HexToAddress(addr))
+			}
 		}
 
 		elClaim, _, _, err := generateClaimPayload(

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -88,7 +88,7 @@ func getClaimFlags() []cli.Flag {
 	return allFlags
 }
 
-func BatchClaim(
+func batchClaim(
 	ctx context.Context,
 	logger logging.Logger,
 	ethClient *ethclient.Client,
@@ -260,7 +260,7 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 	}
 
 	if config.BatchClaimFile != "" {
-		return BatchClaim(ctx, logger, ethClient, elReader, df, config, p, claimDate, rootIndex, proofData)
+		return batchClaim(ctx, logger, ethClient, elReader, df, config, p, claimDate, rootIndex, proofData)
 	}
 
 	elClaim, claim, account, err := generateClaimPayload(

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -95,6 +95,9 @@ func BatchClaim(
 	df *httpProofDataFetcher.HttpProofDataFetcher,
 	config *ClaimConfig,
 	p utils.Prompter,
+	claimDate string,
+	rootIndex uint32,
+	proofData *proofDataFetcher.RewardProofData,
 ) error {
 	ctx := cCtx.Context
 	logger := common.GetLogger(cCtx)
@@ -112,16 +115,6 @@ func BatchClaim(
 	err = yaml.Unmarshal(yamlFile, &claimConfigs)
 	if err != nil {
 		return eigenSdkUtils.WrapError("failed to parse YAML config", err)
-	}
-
-	claimDate, rootIndex, err := getClaimDistributionRoot(ctx, config.ClaimTimestamp, elReader, logger)
-	if err != nil {
-		return eigenSdkUtils.WrapError("failed to get claim distribution root", err)
-	}
-
-	proofData, err := df.FetchClaimAmountsForDate(ctx, claimDate)
-	if err != nil {
-		return eigenSdkUtils.WrapError("failed to fetch claim amounts for date", err)
 	}
 
 	var elClaims []rewardscoordinator.IRewardsCoordinatorRewardsMerkleClaim
@@ -267,7 +260,7 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 	}
 
 	if config.BatchClaimFile != "" {
-		return BatchClaim(cCtx, ethClient, elReader, df, config, p)
+		return BatchClaim(cCtx, ethClient, elReader, df, config, p, claimDate, rootIndex, proofData)
 	}
 
 	elClaim, claim, account, err := generateClaimPayload(

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -86,37 +86,9 @@ func getClaimFlags() []cli.Flag {
 	return allFlags
 }
 
-func BatchClaim(cCtx *cli.Context, p utils.Prompter) error {
+func BatchClaim(cCtx *cli.Context, ethClient *ethclient.Client, elReader *elcontracts.ChainReader, df *httpProofDataFetcher.HttpProofDataFetcher, config *ClaimConfig, p utils.Prompter) error {
 	ctx := cCtx.Context
 	logger := common.GetLogger(cCtx)
-
-	config, err := readAndValidateClaimConfig(cCtx, logger)
-	if err != nil {
-		return eigenSdkUtils.WrapError("failed to read and validate claim config", err)
-	}
-	cCtx.App.Metadata["network"] = config.ChainID.String()
-
-	ethClient, err := ethclient.Dial(config.RPCUrl)
-	if err != nil {
-		return eigenSdkUtils.WrapError("failed to create new eth client", err)
-	}
-
-	elReader, err := elcontracts.NewReaderFromConfig(
-		elcontracts.Config{
-			RewardsCoordinatorAddress: config.RewardsCoordinatorAddress,
-		},
-		ethClient, logger,
-	)
-	if err != nil {
-		return eigenSdkUtils.WrapError("failed to create new reader from config", err)
-	}
-
-	df := httpProofDataFetcher.NewHttpProofDataFetcher(
-		config.ProofStoreBaseURL,
-		config.Environment,
-		config.Network,
-		http.DefaultClient,
-	)
 
 	yamlFile, err := os.ReadFile(config.BatchClaimFile)
 	if err != nil {
@@ -264,10 +236,6 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 		return eigenSdkUtils.WrapError("failed to read and validate claim config", err)
 	}
 
-	if config.BatchClaimFile != "" {
-		return BatchClaim(cCtx, p)
-	}
-
 	cCtx.App.Metadata["network"] = config.ChainID.String()
 
 	ethClient, err := ethclient.Dial(config.RPCUrl)
@@ -291,6 +259,10 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 		config.Network,
 		http.DefaultClient,
 	)
+
+	if config.BatchClaimFile != "" {
+		return BatchClaim(cCtx, ethClient, elReader, df, config, p)
+	}
 
 	elClaim, claim, accounts, err := claimHelper(config.ClaimTimestamp, ctx, elReader, logger, config.EarnerAddress, df, config.TokenAddresses)
 

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -115,7 +115,7 @@ func BatchClaim(cCtx *cli.Context, ethClient *ethclient.Client, elReader *elcont
 			tokenAddrs = append(tokenAddrs, gethcommon.HexToAddress(addr))
 		}
 
-		elClaim, _, _, err := claimHelper(ctx, config.ClaimTimestamp, elReader, logger, earnerAddr, df, tokenAddrs)
+		elClaim, _, _, err := generateClaimPayload(ctx, config.ClaimTimestamp, elReader, logger, earnerAddr, df, tokenAddrs)
 
 		elClaims = append(elClaims, *elClaim)
 
@@ -156,7 +156,7 @@ func BatchClaim(cCtx *cli.Context, ethClient *ethclient.Client, elReader *elcont
 	return nil
 }
 
-func claimHelper(
+func generateClaimPayload(
 	ctx context.Context,
 	claimTimestamp string,
 	elReader *elcontracts.ChainReader,
@@ -260,7 +260,7 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 		return BatchClaim(cCtx, ethClient, elReader, df, config, p)
 	}
 
-	elClaim, claim, accounts, err := claimHelper(ctx, config.ClaimTimestamp, elReader, logger, config.EarnerAddress, df, config.TokenAddresses)
+	elClaim, claim, accounts, err := generateClaimPayload(ctx, config.ClaimTimestamp, elReader, logger, config.EarnerAddress, df, config.TokenAddresses)
 
 	if err != nil {
 		return err

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -316,7 +316,7 @@ func broadcastClaims(config *ClaimConfig,
 
 		var receipt *types.Receipt
 
-		if len(*elClaims) > 0 {
+		if len(*elClaims) > 1 {
 			receipt, err = eLWriter.ProcessClaims(ctx, *elClaims, config.RecipientAddress, true)
 		} else {
 			receipt, err = eLWriter.ProcessClaim(ctx, (*elClaims)[0], config.RecipientAddress, true)

--- a/pkg/rewards/types.go
+++ b/pkg/rewards/types.go
@@ -32,6 +32,7 @@ type ClaimConfig struct {
 	Environment               string
 	SignerConfig              *types.SignerConfig
 	IsSilent                  bool
+	BatchClaimFile            string
 }
 
 type SetClaimerConfig struct {

--- a/samples/batch-claims.yaml
+++ b/samples/batch-claims.yaml
@@ -1,0 +1,6 @@
+- earner_address: "0x025246421e7247a729bbcff652c5cc1815ac6373"
+  token_addresses:
+    - "0x3B78576F7D6837500bA3De27A60c7f594934027E"
+- earner_address: "0x025246421e7247a729bbcff652c5cc1815ac6373"
+  token_addresses:
+    - "0x3B78576F7D6837500bA3De27A60c7f594934027E"

--- a/samples/batch-claims.yaml
+++ b/samples/batch-claims.yaml
@@ -4,3 +4,4 @@
 - earner_address: "0x025246421e7247a729bbcff652c5cc1815ac6373"
   token_addresses:
     - "0x3B78576F7D6837500bA3De27A60c7f594934027E"
+  


### PR DESCRIPTION
Adds batch claiming support for rewards v2:
`./eigenlayer rewards claim --earner-address 0x025246421e7247a729bbcff652c5cc1815ac6373 --eth-rpc-url http://rpc-url
--network holesky --batch-claim-file samples/batch-claim.yaml`

Example batch claim file provided in samples/batch-claim.yaml

Eigensdk has been updated to include process claims.


