### PR TITLE
Implementing `list` and `list_permissions` Commands.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Layr-Labs/eigenlayer-contracts v0.3.2-mainnet-rewards
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.12
 	github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-5c11a259293e
-	github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241205221048-fe823e1c912f
+	github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241210000422-beb1a3c4502f
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/gnark-crypto v0.12.1
 	github.com/ethereum/go-ethereum v1.14.5

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241204193922-c60d25970459 h1:37Upmq
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241204193922-c60d25970459/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241205221048-fe823e1c912f h1:A/rKI4aDTTgfzDacgKwyV/XMFdibxbc2WXavaWPzn1Q=
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241205221048-fe823e1c912f/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
+github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241210000422-beb1a3c4502f h1:D94Vf+dALr9W0Ie18lZ8QDPvOAFX8FBbIpyVAtCUL1A=
+github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241210000422-beb1a3c4502f/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=

--- a/pkg/user/appointee/appointee.go
+++ b/pkg/user/appointee/appointee.go
@@ -21,8 +21,8 @@ func AppointeeCmd() *cli.Command {
 		Subcommands: []*cli.Command{
 			BatchSetCmd(),
 			canCallCmd(generateUserCanCallReader),
-			ListCmd(),
-			ListPermissionsCmd(),
+			ListCmd(generateListUsersReader),
+			ListPermissionsCmd(generateListUserPermissionsReader),
 			RemoveCmd(),
 			SetCmd(),
 		},

--- a/pkg/user/appointee/can_call.go
+++ b/pkg/user/appointee/can_call.go
@@ -3,6 +3,8 @@ package appointee
 import (
 	"context"
 	"fmt"
+	"sort"
+
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
@@ -13,7 +15,6 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
-	"sort"
 )
 
 type UserCanCallReader interface {
@@ -59,9 +60,8 @@ func canCall(cliCtx *cli.Context, generator func(logging.Logger, *canCallConfig)
 	}
 
 	result, err := elReader.UserCanCall(ctx, config.UserAddress, config.CallerAddress, config.Target, config.Selector)
-	fmt.Printf("CanCall Result: %v", result)
-	fmt.Println()
-	fmt.Printf("Selector, Target and User: %s, %x, %s", config.Target, string(config.Selector[:]), config.UserAddress)
+	fmt.Printf("CanCall Result: %v\n", result)
+	fmt.Printf("Selector, Target and User: %s, %x, %s\n", config.Target, string(config.Selector[:]), config.UserAddress)
 	return err
 }
 

--- a/pkg/user/appointee/can_call.go
+++ b/pkg/user/appointee/can_call.go
@@ -52,7 +52,7 @@ func canCall(cliCtx *cli.Context, generator func(logging.Logger, *canCallConfig)
 	if err != nil {
 		return eigenSdkUtils.WrapError("failed to read and validate user can call config", err)
 	}
-
+	cliCtx.App.Metadata["network"] = config.ChainID.String()
 	elReader, err := generator(logger, config)
 	if err != nil {
 		return err

--- a/pkg/user/appointee/can_call.go
+++ b/pkg/user/appointee/can_call.go
@@ -13,6 +13,7 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
+	"sort"
 )
 
 type UserCanCallReader interface {
@@ -37,16 +38,7 @@ func canCallCmd(readerGenerator func(logging.Logger, *canCallConfig) (UserCanCal
 			return canCall(c, readerGenerator)
 		},
 		After: telemetry.AfterRunAction(),
-		Flags: []cli.Flag{
-			&AccountAddressFlag,
-			&CallerAddressFlag,
-			&TargetAddressFlag,
-			&SelectorFlag,
-			&PermissionControllerAddressFlag,
-			&flags.NetworkFlag,
-			&flags.EnvironmentFlag,
-			&flags.ETHRpcUrlFlag,
-		},
+		Flags: canCallFlags(),
 	}
 
 	return cmd
@@ -137,4 +129,19 @@ func generateUserCanCallReader(
 		logger,
 	)
 	return elReader, err
+}
+
+func canCallFlags() []cli.Flag {
+	cmdFlags := []cli.Flag{
+		&AccountAddressFlag,
+		&CallerAddressFlag,
+		&TargetAddressFlag,
+		&SelectorFlag,
+		&PermissionControllerAddressFlag,
+		&flags.NetworkFlag,
+		&flags.EnvironmentFlag,
+		&flags.ETHRpcUrlFlag,
+	}
+	sort.Sort(cli.FlagsByName(cmdFlags))
+	return cmdFlags
 }

--- a/pkg/user/appointee/can_call.go
+++ b/pkg/user/appointee/can_call.go
@@ -2,7 +2,7 @@ package appointee
 
 import (
 	"context"
-
+	"fmt"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
@@ -67,8 +67,9 @@ func canCall(cliCtx *cli.Context, generator func(logging.Logger, *canCallConfig)
 	}
 
 	result, err := elReader.UserCanCall(ctx, config.UserAddress, config.CallerAddress, config.Target, config.Selector)
-	logger.Infof("CanCall Result: %v", result)
-	logger.Infof("Selector, Target and User: %s, %x, %s", config.Target, string(config.Selector[:]), config.UserAddress)
+	fmt.Printf("CanCall Result: %v", result)
+	fmt.Println()
+	fmt.Printf("Selector, Target and User: %s, %x, %s", config.Target, string(config.Selector[:]), config.UserAddress)
 	return err
 }
 

--- a/pkg/user/appointee/list.go
+++ b/pkg/user/appointee/list.go
@@ -13,6 +13,7 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
+	"sort"
 )
 
 type ListUsersReader interface {
@@ -36,15 +37,7 @@ func ListCmd(readerGenerator func(logging.Logger, *listUsersConfig) (ListUsersRe
 			return listAppointees(c, readerGenerator)
 		},
 		After: telemetry.AfterRunAction(),
-		Flags: []cli.Flag{
-			&flags.VerboseFlag,
-			&AccountAddressFlag,
-			&TargetAddressFlag,
-			&SelectorFlag,
-			&flags.NetworkFlag,
-			&flags.EnvironmentFlag,
-			&flags.ETHRpcUrlFlag,
-		},
+		Flags: listFlags(),
 	}
 
 	return listCmd
@@ -148,4 +141,18 @@ func generateListUsersReader(logger logging.Logger, config *listUsersConfig) (Li
 		logger,
 	)
 	return elReader, err
+}
+
+func listFlags() []cli.Flag {
+	cmdFlags := []cli.Flag{
+		&flags.VerboseFlag,
+		&AccountAddressFlag,
+		&TargetAddressFlag,
+		&SelectorFlag,
+		&flags.NetworkFlag,
+		&flags.EnvironmentFlag,
+		&flags.ETHRpcUrlFlag,
+	}
+	sort.Sort(cli.FlagsByName(cmdFlags))
+	return cmdFlags
 }

--- a/pkg/user/appointee/list.go
+++ b/pkg/user/appointee/list.go
@@ -3,6 +3,9 @@ package appointee
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
@@ -13,7 +16,6 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
-	"sort"
 )
 
 type ListUsersReader interface {
@@ -75,7 +77,7 @@ func printResults(config *listUsersConfig, users []gethcommon.Address) {
 		string(config.Selector[:]),
 		config.UserAddress,
 	)
-	fmt.Println("====================================================================================")
+	fmt.Println(strings.Repeat("-", 80))
 
 	for _, user := range users {
 		fmt.Printf("User Id: 0x%b\n", user)

--- a/pkg/user/appointee/list.go
+++ b/pkg/user/appointee/list.go
@@ -1,12 +1,30 @@
 package appointee
 
 import (
+	"context"
+	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
 )
 
-func ListCmd() *cli.Command {
+type ListUsersReader interface {
+	ListUsers(
+		ctx context.Context,
+		userAddress gethcommon.Address,
+		target gethcommon.Address,
+		selector [4]byte,
+	) ([]gethcommon.Address, error)
+}
+
+func ListCmd(readerGenerator func(logging.Logger, *listUsersConfig) (ListUsersReader, error)) *cli.Command {
 	listCmd := &cli.Command{
 		Name:      "list",
 		Usage:     "user appointee list --account-address <AccountAddress> --target-address <TargetAddress> --selector <Selector>",
@@ -14,12 +32,120 @@ func ListCmd() *cli.Command {
 		Description: `
 		Lists all appointed users for an account with the provided permissions.
 		`,
+		Action: func(c *cli.Context) error {
+			return listAppointees(c, readerGenerator)
+		},
 		After: telemetry.AfterRunAction(),
 		Flags: []cli.Flag{
 			&flags.VerboseFlag,
 			&AccountAddressFlag,
+			&TargetAddressFlag,
+			&SelectorFlag,
+			&flags.NetworkFlag,
+			&flags.EnvironmentFlag,
+			&flags.ETHRpcUrlFlag,
 		},
 	}
 
 	return listCmd
+}
+
+func listAppointees(
+	cliCtx *cli.Context,
+	generator func(logging.Logger, *listUsersConfig) (ListUsersReader, error),
+) error {
+	ctx := cliCtx.Context
+	logger := common.GetLogger(cliCtx)
+
+	config, err := readAndValidateListUsersConfig(cliCtx, logger)
+	if err != nil {
+		return eigenSdkUtils.WrapError("failed to read and validate user can call config", err)
+	}
+
+	elReader, err := generator(logger, config)
+	if err != nil {
+		return err
+	}
+
+	users, err := elReader.ListUsers(ctx, config.UserAddress, config.Target, config.Selector)
+	if err != nil {
+		return err
+	}
+	printResults(config, users)
+	return nil
+}
+
+func printResults(config *listUsersConfig, users []gethcommon.Address) {
+	fmt.Printf(
+		"Selector, Target and Appointer: %s, %x, %s",
+		config.Target,
+		string(config.Selector[:]),
+		config.UserAddress,
+	)
+	fmt.Println("====================================================================================")
+
+	for _, user := range users {
+		fmt.Printf("User Id: 0x%b\n", user)
+	}
+}
+
+func readAndValidateListUsersConfig(cliContext *cli.Context, logger logging.Logger) (*listUsersConfig, error) {
+	userAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
+	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
+	network := cliContext.String(flags.NetworkFlag.Name)
+	environment := cliContext.String(flags.EnvironmentFlag.Name)
+	target := gethcommon.HexToAddress(cliContext.String(TargetAddressFlag.Name))
+	selector := cliContext.String(SelectorFlag.Name)
+	selectorBytes, err := common.ValidateAndConvertSelectorString(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	if environment == "" {
+		environment = common.GetEnvFromNetwork(network)
+	}
+
+	chainID := utils.NetworkNameToChainId(network)
+	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+
+	if common.IsEmptyString(permissionManagerAddress) {
+		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	logger.Debugf(
+		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		environment,
+		network,
+		chainID,
+		permissionManagerAddress,
+	)
+
+	return &listUsersConfig{
+		Network:                  network,
+		RPCUrl:                   ethRpcUrl,
+		UserAddress:              userAddress,
+		Target:                   target,
+		Selector:                 selectorBytes,
+		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
+		ChainID:                  chainID,
+		Environment:              environment,
+	}, nil
+}
+
+func generateListUsersReader(logger logging.Logger, config *listUsersConfig) (ListUsersReader, error) {
+	ethClient, err := ethclient.Dial(config.RPCUrl)
+	if err != nil {
+		return nil, eigenSdkUtils.WrapError("failed to create new eth client", err)
+	}
+	elReader, err := elcontracts.NewReaderFromConfig(
+		elcontracts.Config{
+			PermissionsControllerAddress: config.PermissionManagerAddress,
+		},
+		ethClient,
+		logger,
+	)
+	return elReader, err
 }

--- a/pkg/user/appointee/list.go
+++ b/pkg/user/appointee/list.go
@@ -99,6 +99,7 @@ func readAndValidateListUsersConfig(cliContext *cli.Context, logger logging.Logg
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
+	cliContext.App.Metadata["network"] = chainID.String()
 	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
 	if common.IsEmptyString(permissionManagerAddress) {

--- a/pkg/user/appointee/list_permissions.go
+++ b/pkg/user/appointee/list_permissions.go
@@ -3,6 +3,8 @@ package appointee
 import (
 	"context"
 	"fmt"
+	"sort"
+
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
@@ -13,7 +15,6 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
-	"sort"
 )
 
 type PermissionsReader interface {

--- a/pkg/user/appointee/list_permissions.go
+++ b/pkg/user/appointee/list_permissions.go
@@ -24,7 +24,9 @@ type PermissionsReader interface {
 	) ([]gethcommon.Address, [][4]byte, error)
 }
 
-func ListPermissionsCmd(readerGenerator func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error)) *cli.Command {
+func ListPermissionsCmd(
+	readerGenerator func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error),
+) *cli.Command {
 	cmd := &cli.Command{
 		Name:      "list-permissions",
 		Usage:     "user appointee list-permissions --account-address <AccountAddress> --appointee-address <AppointeeAddress>",
@@ -42,7 +44,10 @@ func ListPermissionsCmd(readerGenerator func(logging.Logger, *listUserPermission
 	return cmd
 }
 
-func listPermissions(cliCtx *cli.Context, generator func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error)) error {
+func listPermissions(
+	cliCtx *cli.Context,
+	generator func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error),
+) error {
 	ctx := cliCtx.Context
 	logger := common.GetLogger(cliCtx)
 
@@ -64,7 +69,10 @@ func listPermissions(cliCtx *cli.Context, generator func(logging.Logger, *listUs
 	return nil
 }
 
-func readAndValidateListUserPermissionsConfig(cliContext *cli.Context, logger logging.Logger) (*listUserPermissionsConfig, error) {
+func readAndValidateListUserPermissionsConfig(
+	cliContext *cli.Context,
+	logger logging.Logger,
+) (*listUserPermissionsConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	userAddress := gethcommon.HexToAddress(cliContext.String(AppointeeAddressFlag.Name))
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)

--- a/pkg/user/appointee/list_permissions.go
+++ b/pkg/user/appointee/list_permissions.go
@@ -1,26 +1,143 @@
 package appointee
 
 import (
+	"context"
+	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
+	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
 )
 
-func ListPermissionsCmd() *cli.Command {
-	listPermissions := &cli.Command{
+type PermissionsReader interface {
+	ListUserPermissions(
+		ctx context.Context,
+		appointed gethcommon.Address,
+		userAddress gethcommon.Address,
+	) ([]gethcommon.Address, [][4]byte, error)
+}
+
+func ListPermissionsCmd(readerGenerator func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error)) *cli.Command {
+	cmd := &cli.Command{
 		Name:      "list-permissions",
 		Usage:     "user appointee list-permissions --account-address <AccountAddress> --appointee-address <AppointeeAddress>",
 		UsageText: "List all permissions for a user.",
 		Description: `
 		List all permissions of a user.
 		`,
+		Action: func(c *cli.Context) error {
+			return listPermissions(c, readerGenerator)
+		},
 		After: telemetry.AfterRunAction(),
 		Flags: []cli.Flag{
 			&flags.VerboseFlag,
 			&AccountAddressFlag,
 			&AppointeeAddressFlag,
+			&flags.NetworkFlag,
+			&flags.EnvironmentFlag,
+			&flags.ETHRpcUrlFlag,
 		},
 	}
 
-	return listPermissions
+	return cmd
+}
+
+func listPermissions(cliCtx *cli.Context, generator func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error)) error {
+	ctx := cliCtx.Context
+	logger := common.GetLogger(cliCtx)
+
+	config, err := readAndValidateListUserPermissionsConfig(cliCtx, logger)
+	if err != nil {
+		return eigenSdkUtils.WrapError("failed to read and validate list user permissions config", err)
+	}
+
+	reader, err := generator(logger, config)
+	if err != nil {
+		return err
+	}
+
+	users, permissions, err := reader.ListUserPermissions(ctx, config.AccountAddress, config.UserAddress)
+	if err != nil {
+		return err
+	}
+	printPermissions(config, users, permissions)
+	return nil
+}
+
+func readAndValidateListUserPermissionsConfig(cliContext *cli.Context, logger logging.Logger) (*listUserPermissionsConfig, error) {
+	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
+	userAddress := gethcommon.HexToAddress(cliContext.String(AppointeeAddressFlag.Name))
+	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
+	network := cliContext.String(flags.NetworkFlag.Name)
+	environment := cliContext.String(flags.EnvironmentFlag.Name)
+
+	if environment == "" {
+		environment = common.GetEnvFromNetwork(network)
+	}
+
+	chainID := utils.NetworkNameToChainId(network)
+	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+
+	var err error
+	if common.IsEmptyString(permissionManagerAddress) {
+		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	logger.Debugf(
+		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		environment,
+		network,
+		chainID,
+		permissionManagerAddress,
+	)
+
+	return &listUserPermissionsConfig{
+		Network:                  network,
+		RPCUrl:                   ethRpcUrl,
+		AccountAddress:           accountAddress,
+		UserAddress:              userAddress,
+		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
+		ChainID:                  chainID,
+		Environment:              environment,
+	}, nil
+}
+
+func printPermissions(config *listUserPermissionsConfig, targets []gethcommon.Address, selectors [][4]byte) {
+	fmt.Printf("User: %s\n", config.UserAddress)
+	fmt.Printf("Appointed by: %s\n", config.AccountAddress)
+	fmt.Println("====================================================================================")
+
+	for _, target := range targets {
+		for _, selector := range selectors {
+			fmt.Printf("Target: %s, Selector: %x\n", target, selector)
+		}
+
+	}
+}
+
+func generateListUserPermissionsReader(
+	logger logging.Logger,
+	config *listUserPermissionsConfig,
+) (PermissionsReader, error) {
+	ethClient, err := ethclient.Dial(config.RPCUrl)
+	if err != nil {
+		return nil, eigenSdkUtils.WrapError("failed to create new eth client", err)
+	}
+	elReader, err := elcontracts.NewReaderFromConfig(
+		elcontracts.Config{
+			PermissionsControllerAddress: config.PermissionManagerAddress,
+		},
+		ethClient,
+		logger,
+	)
+	return elReader, err
 }

--- a/pkg/user/appointee/list_permissions.go
+++ b/pkg/user/appointee/list_permissions.go
@@ -56,6 +56,7 @@ func listPermissions(
 		return eigenSdkUtils.WrapError("failed to read and validate list user permissions config", err)
 	}
 
+	cliCtx.App.Metadata["network"] = config.ChainID.String()
 	reader, err := generator(logger, config)
 	if err != nil {
 		return err

--- a/pkg/user/appointee/list_permissions.go
+++ b/pkg/user/appointee/list_permissions.go
@@ -13,6 +13,7 @@ import (
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/urfave/cli/v2"
+	"sort"
 )
 
 type PermissionsReader interface {
@@ -35,14 +36,7 @@ func ListPermissionsCmd(readerGenerator func(logging.Logger, *listUserPermission
 			return listPermissions(c, readerGenerator)
 		},
 		After: telemetry.AfterRunAction(),
-		Flags: []cli.Flag{
-			&flags.VerboseFlag,
-			&AccountAddressFlag,
-			&AppointeeAddressFlag,
-			&flags.NetworkFlag,
-			&flags.EnvironmentFlag,
-			&flags.ETHRpcUrlFlag,
-		},
+		Flags: listPermissionFlags(),
 	}
 
 	return cmd
@@ -140,4 +134,17 @@ func generateListUserPermissionsReader(
 		logger,
 	)
 	return elReader, err
+}
+
+func listPermissionFlags() []cli.Flag {
+	cmdFlags := []cli.Flag{
+		&flags.VerboseFlag,
+		&AccountAddressFlag,
+		&AppointeeAddressFlag,
+		&flags.NetworkFlag,
+		&flags.EnvironmentFlag,
+		&flags.ETHRpcUrlFlag,
+	}
+	sort.Sort(cli.FlagsByName(cmdFlags))
+	return cmdFlags
 }

--- a/pkg/user/appointee/list_permissions_test.go
+++ b/pkg/user/appointee/list_permissions_test.go
@@ -19,7 +19,11 @@ type mockListPermissionsReader struct {
 	) ([]gethcommon.Address, [][4]byte, error)
 }
 
-func newMockListPermissionsReader(users []gethcommon.Address, permissions [][4]byte, err error) *mockListPermissionsReader {
+func newMockListPermissionsReader(
+	users []gethcommon.Address,
+	permissions [][4]byte,
+	err error,
+) *mockListPermissionsReader {
 	return &mockListPermissionsReader{
 		listPermissionsFunc: func(ctx context.Context, appointed, userAddress gethcommon.Address) ([]gethcommon.Address, [][4]byte, error) {
 			return users, permissions, err
@@ -35,7 +39,11 @@ func (m *mockListPermissionsReader) ListUserPermissions(
 	return m.listPermissionsFunc(ctx, appointed, userAddress)
 }
 
-func generateMockListPermissionsReader(users []gethcommon.Address, permissions [][4]byte, err error) func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error) {
+func generateMockListPermissionsReader(
+	users []gethcommon.Address,
+	permissions [][4]byte,
+	err error,
+) func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error) {
 	return func(logger logging.Logger, config *listUserPermissionsConfig) (PermissionsReader, error) {
 		return newMockListPermissionsReader(users, permissions, err), nil
 	}

--- a/pkg/user/appointee/list_permissions_test.go
+++ b/pkg/user/appointee/list_permissions_test.go
@@ -1,0 +1,108 @@
+package appointee
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+type mockListPermissionsReader struct {
+	listPermissionsFunc func(
+		ctx context.Context,
+		appointed gethcommon.Address,
+		userAddress gethcommon.Address,
+	) ([]gethcommon.Address, [][4]byte, error)
+}
+
+func newMockListPermissionsReader(users []gethcommon.Address, permissions [][4]byte, err error) *mockListPermissionsReader {
+	return &mockListPermissionsReader{
+		listPermissionsFunc: func(ctx context.Context, appointed, userAddress gethcommon.Address) ([]gethcommon.Address, [][4]byte, error) {
+			return users, permissions, err
+		},
+	}
+}
+
+func (m *mockListPermissionsReader) ListUserPermissions(
+	ctx context.Context,
+	appointed gethcommon.Address,
+	userAddress gethcommon.Address,
+) ([]gethcommon.Address, [][4]byte, error) {
+	return m.listPermissionsFunc(ctx, appointed, userAddress)
+}
+
+func generateMockListPermissionsReader(users []gethcommon.Address, permissions [][4]byte, err error) func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error) {
+	return func(logger logging.Logger, config *listUserPermissionsConfig) (PermissionsReader, error) {
+		return newMockListPermissionsReader(users, permissions, err), nil
+	}
+}
+
+func TestListPermissions_Success(t *testing.T) {
+	expectedUsers := []gethcommon.Address{
+		gethcommon.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+	}
+	expectedPermissions := [][4]byte{
+		{0x1A, 0x2B, 0x3C, 0x4D},
+	}
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ListPermissionsCmd(generateMockListPermissionsReader(expectedUsers, expectedPermissions, nil)),
+	}
+
+	args := []string{
+		"TestListPermissions_Success",
+		"list-permissions",
+		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--appointee-address", "0x9876543210fedcba9876543210fedcba98765432",
+		"--network", "holesky",
+		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
+	}
+
+	err := app.Run(args)
+	assert.NoError(t, err)
+}
+
+func TestListPermissions_ReaderError(t *testing.T) {
+	expectedError := "Error fetching permissions"
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ListPermissionsCmd(generateMockListPermissionsReader(nil, nil, errors.New(expectedError))),
+	}
+
+	args := []string{
+		"TestListPermissions_ReaderError",
+		"list-permissions",
+		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--appointee-address", "0x9876543210fedcba9876543210fedcba98765432",
+		"--network", "holesky",
+		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
+	}
+
+	err := app.Run(args)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), expectedError)
+}
+
+func TestListPermissions_NoPermissions(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ListPermissionsCmd(generateMockListPermissionsReader([]gethcommon.Address{}, [][4]byte{}, nil)),
+	}
+
+	args := []string{
+		"TestListPermissions_NoPermissions",
+		"list-permissions",
+		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--appointee-address", "0x9876543210fedcba9876543210fedcba98765432",
+		"--network", "holesky",
+		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
+	}
+
+	err := app.Run(args)
+	assert.NoError(t, err)
+}

--- a/pkg/user/appointee/list_test.go
+++ b/pkg/user/appointee/list_test.go
@@ -36,7 +36,10 @@ func (m *mockListUsersReader) ListUsers(
 	return m.listUsersFunc(ctx, userAddress, target, selector)
 }
 
-func generateMockListReader(users []gethcommon.Address, err error) func(logging.Logger, *listUsersConfig) (ListUsersReader, error) {
+func generateMockListReader(
+	users []gethcommon.Address,
+	err error,
+) func(logging.Logger, *listUsersConfig) (ListUsersReader, error) {
 	return func(logger logging.Logger, config *listUsersConfig) (ListUsersReader, error) {
 		return newMockListUsersReader(users, err), nil
 	}

--- a/pkg/user/appointee/list_test.go
+++ b/pkg/user/appointee/list_test.go
@@ -1,0 +1,131 @@
+package appointee
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+)
+
+type mockListUsersReader struct {
+	listUsersFunc func(
+		ctx context.Context,
+		userAddress gethcommon.Address,
+		target gethcommon.Address,
+		selector [4]byte,
+	) ([]gethcommon.Address, error)
+}
+
+func newMockListUsersReader(users []gethcommon.Address, err error) *mockListUsersReader {
+	return &mockListUsersReader{
+		listUsersFunc: func(ctx context.Context, userAddress, target gethcommon.Address, selector [4]byte) ([]gethcommon.Address, error) {
+			return users, err
+		},
+	}
+}
+
+func (m *mockListUsersReader) ListUsers(
+	ctx context.Context,
+	userAddress, target gethcommon.Address,
+	selector [4]byte,
+) ([]gethcommon.Address, error) {
+	return m.listUsersFunc(ctx, userAddress, target, selector)
+}
+
+func generateMockListReader(users []gethcommon.Address, err error) func(logging.Logger, *listUsersConfig) (ListUsersReader, error) {
+	return func(logger logging.Logger, config *listUsersConfig) (ListUsersReader, error) {
+		return newMockListUsersReader(users, err), nil
+	}
+}
+
+func TestListAppointees_Success(t *testing.T) {
+	expectedUsers := []gethcommon.Address{
+		gethcommon.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+		gethcommon.HexToAddress("0x9876543210fedcba9876543210fedcba98765432"),
+	}
+
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ListCmd(generateMockListReader(expectedUsers, nil)),
+	}
+
+	args := []string{
+		"TestListAppointees_Success",
+		"list",
+		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--target-address", "0xabcdef1234567890abcdef1234567890abcdef12",
+		"--selector", "0x1A2B3C4D",
+		"--network", "holesky",
+		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
+	}
+
+	err := app.Run(args)
+	assert.NoError(t, err)
+}
+
+func TestListAppointees_ReaderError(t *testing.T) {
+	expectedError := "Error fetching appointees"
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ListCmd(generateMockListReader(nil, errors.New(expectedError))),
+	}
+
+	args := []string{
+		"TestListAppointees_ReaderError",
+		"list",
+		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--target-address", "0xabcdef1234567890abcdef1234567890abcdef12",
+		"--selector", "0x1A2B3C4D",
+		"--network", "holesky",
+		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
+	}
+
+	err := app.Run(args)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), expectedError)
+}
+
+func TestListAppointees_InvalidSelector(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ListCmd(generateMockListReader(nil, nil)),
+	}
+
+	args := []string{
+		"TestListAppointees_InvalidSelector",
+		"list",
+		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--target-address", "0xabcdef1234567890abcdef1234567890abcdef12",
+		"--selector", "invalid",
+		"--network", "holesky",
+		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
+	}
+
+	err := app.Run(args)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "selector must be a 4-byte hex string prefixed with '0x'")
+}
+
+func TestListAppointees_NoUsers(t *testing.T) {
+	app := cli.NewApp()
+	app.Commands = []*cli.Command{
+		ListCmd(generateMockListReader([]gethcommon.Address{}, nil)),
+	}
+
+	args := []string{
+		"TestListAppointees_NoUsers",
+		"list",
+		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--target-address", "0xabcdef1234567890abcdef1234567890abcdef12",
+		"--selector", "0x1A2B3C4D",
+		"--network", "holesky",
+		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
+	}
+
+	err := app.Run(args)
+	assert.NoError(t, err)
+}

--- a/pkg/user/appointee/types.go
+++ b/pkg/user/appointee/types.go
@@ -17,3 +17,25 @@ type canCallConfig struct {
 	ChainID                  *big.Int
 	Environment              string
 }
+
+type listUsersConfig struct {
+	Network                  string
+	RPCUrl                   string
+	AccountAddress           gethcommon.Address
+	UserAddress              gethcommon.Address
+	Target                   gethcommon.Address
+	Selector                 [4]byte
+	PermissionManagerAddress gethcommon.Address
+	ChainID                  *big.Int
+	Environment              string
+}
+
+type listUserPermissionsConfig struct {
+	Network                  string
+	RPCUrl                   string
+	AccountAddress           gethcommon.Address
+	UserAddress              gethcommon.Address
+	PermissionManagerAddress gethcommon.Address
+	ChainID                  *big.Int
+	Environment              string
+}


### PR DESCRIPTION
Implementing `list` and `list_permissions` Commands.

### What Changed?
 - Minor refactors for `can-call` command.
 - Added `user list` command.
 - Added `user list-permissions` command.
 - Added unit tests for both commands.
