### PR TITLE
Cleaning up user command flags.

### DIFF
--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -122,15 +122,17 @@ func acceptFlags() []cli.Flag {
 	cmdFlags := []cli.Flag{
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
+		&PermissionControllerAddressFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,
+		&flags.BroadcastFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,
-		&PermissionControllerAddressFlag,
 	}
+	cmdFlags = append(cmdFlags, flags.GetSignerFlags()...)
 	sort.Sort(cli.FlagsByName(cmdFlags))
-	return append(cmdFlags, flags.GetSignerFlags()...)
+	return cmdFlags
 }
 
 func generateAcceptAdminWriter(

--- a/pkg/user/admin/add_pending.go
+++ b/pkg/user/admin/add_pending.go
@@ -151,13 +151,15 @@ func addPendingFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AdminAddressFlag,
+		&PermissionControllerAddressFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,
+		&flags.BroadcastFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,
-		&PermissionControllerAddressFlag,
 	}
+	cmdFlags = append(cmdFlags, flags.GetSignerFlags()...)
 	sort.Sort(cli.FlagsByName(cmdFlags))
-	return append(cmdFlags, flags.GetSignerFlags()...)
+	return cmdFlags
 }

--- a/pkg/user/admin/is_admin.go
+++ b/pkg/user/admin/is_admin.go
@@ -134,8 +134,6 @@ func IsAdminFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&CallerAddressFlag,
-		&flags.OutputTypeFlag,
-		&flags.OutputFileFlag,
 		&PermissionControllerAddressFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,

--- a/pkg/user/admin/is_pending.go
+++ b/pkg/user/admin/is_pending.go
@@ -142,8 +142,6 @@ func isPendingAdminFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&PendingAdminAddressFlag,
-		&flags.OutputTypeFlag,
-		&flags.OutputFileFlag,
 		&PermissionControllerAddressFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,

--- a/pkg/user/admin/list.go
+++ b/pkg/user/admin/list.go
@@ -134,8 +134,6 @@ func listAdminFlags() []cli.Flag {
 	cmdFlags := []cli.Flag{
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
-		&flags.OutputFileFlag,
-		&flags.OutputTypeFlag,
 		&PermissionControllerAddressFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,

--- a/pkg/user/admin/list_pending.go
+++ b/pkg/user/admin/list_pending.go
@@ -142,8 +142,6 @@ func listPendingAdminsFlags() []cli.Flag {
 	cmdFlags := []cli.Flag{
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
-		&flags.OutputTypeFlag,
-		&flags.OutputFileFlag,
 		&PermissionControllerAddressFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,

--- a/pkg/user/admin/remove.go
+++ b/pkg/user/admin/remove.go
@@ -151,13 +151,15 @@ func removeFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AdminAddressFlag,
+		&PermissionControllerAddressFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,
+		&flags.BroadcastFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,
-		&PermissionControllerAddressFlag,
 	}
+	cmdFlags = append(cmdFlags, flags.GetSignerFlags()...)
 	sort.Sort(cli.FlagsByName(cmdFlags))
-	return append(cmdFlags, flags.GetSignerFlags()...)
+	return cmdFlags
 }

--- a/pkg/user/admin/remove_pending.go
+++ b/pkg/user/admin/remove_pending.go
@@ -153,13 +153,15 @@ func removePendingAdminFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AdminAddressFlag,
+		&PermissionControllerAddressFlag,
+		&flags.BroadcastFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,
-		&PermissionControllerAddressFlag,
 	}
+	cmdFlags = append(cmdFlags, flags.GetSignerFlags()...)
 	sort.Sort(cli.FlagsByName(cmdFlags))
-	return append(cmdFlags, flags.GetSignerFlags()...)
+	return cmdFlags
 }

--- a/pkg/user/appointee/batch_set.go
+++ b/pkg/user/appointee/batch_set.go
@@ -27,7 +27,14 @@ func batchSetFlags() []cli.Flag {
 	cmdFlags := []cli.Flag{
 		&flags.VerboseFlag,
 		&BatchSetFileFlag,
+		// TODO: any other flags related to command inputs.
+		&PermissionControllerAddressFlag,
+		&flags.NetworkFlag,
+		&flags.EnvironmentFlag,
+		&flags.ETHRpcUrlFlag,
+		&flags.BroadcastFlag,
 	}
+	cmdFlags = append(cmdFlags, flags.GetSignerFlags()...)
 	sort.Sort(cli.FlagsByName(cmdFlags))
-	return append(cmdFlags, flags.GetSignerFlags()...)
+	return cmdFlags
 }

--- a/pkg/user/appointee/list.go
+++ b/pkg/user/appointee/list.go
@@ -152,6 +152,7 @@ func listFlags() []cli.Flag {
 		&AccountAddressFlag,
 		&TargetAddressFlag,
 		&SelectorFlag,
+		&PermissionControllerAddressFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,

--- a/pkg/user/appointee/list_permissions.go
+++ b/pkg/user/appointee/list_permissions.go
@@ -151,6 +151,7 @@ func listPermissionFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AppointeeAddressFlag,
+		&PermissionControllerAddressFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,

--- a/pkg/user/appointee/remove.go
+++ b/pkg/user/appointee/remove.go
@@ -165,10 +165,13 @@ func removeCommandFlags() []cli.Flag {
 		&AppointeeAddressFlag,
 		&TargetAddressFlag,
 		&SelectorFlag,
+		&PermissionControllerAddressFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,
+		&flags.BroadcastFlag,
 	}
+	cmdFlags = append(cmdFlags, flags.GetSignerFlags()...)
 	sort.Sort(cli.FlagsByName(cmdFlags))
-	return append(cmdFlags, flags.GetSignerFlags()...)
+	return cmdFlags
 }

--- a/pkg/user/appointee/set.go
+++ b/pkg/user/appointee/set.go
@@ -165,10 +165,13 @@ func setCommandFlags() []cli.Flag {
 		&AppointeeAddressFlag,
 		&TargetAddressFlag,
 		&SelectorFlag,
+		&PermissionControllerAddressFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,
+		&flags.BroadcastFlag,
 	}
+	cmdFlags = append(cmdFlags, flags.GetSignerFlags()...)
 	sort.Sort(cli.FlagsByName(cmdFlags))
-	return append(cmdFlags, flags.GetSignerFlags()...)
+	return cmdFlags
 }


### PR DESCRIPTION
Cleaning up user command flags.

### What Changed?
 - Removing output type/file flags where not needed.
 - sorting flags after fully collected.
