### PR TITLE
Refactoring user commands to remove user nomenclature and replacing with appointee

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Layr-Labs/eigenlayer-contracts v0.3.2-mainnet-rewards
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.12
 	github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-5c11a259293e
-	github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241211204646-f49e96f7ee7a
+	github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241212003044-37139a7d8ea8
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/gnark-crypto v0.12.1
 	github.com/ethereum/go-ethereum v1.14.5

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241211204347-52f4546fdec2 h1:NY7ol9
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241211204347-52f4546fdec2/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241211204646-f49e96f7ee7a h1:U1pibFpUsMfL8h9EGrHtm/z94nKKuEvLdWEpkCkCZr4=
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241211204646-f49e96f7ee7a/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
+github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241212003044-37139a7d8ea8 h1:flOwiF9Z9xburwDodNbd6VBi8rzzNSbRy2KG5kqoAak=
+github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241212003044-37139a7d8ea8/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=

--- a/pkg/user/admin/flags.go
+++ b/pkg/user/admin/flags.go
@@ -15,12 +15,6 @@ var (
 		Usage:   "user admin ... --admin-address \"0x...\"",
 		EnvVars: []string{"ADMIN_ADDRESS"},
 	}
-	CallerAddressFlag = cli.StringFlag{
-		Name:    "caller-address",
-		Aliases: []string{"ca"},
-		Usage:   "user admin ... --caller-address \"0x...\"",
-		EnvVars: []string{"CALLER_ADDRESS"},
-	}
 	PendingAdminAddressFlag = cli.StringFlag{
 		Name:    "pending-admin-address",
 		Aliases: []string{"paa"},

--- a/pkg/user/admin/is_admin.go
+++ b/pkg/user/admin/is_admin.go
@@ -29,7 +29,7 @@ type IsAdminReader interface {
 func IsAdminCmd(readerGenerator func(logging.Logger, *isAdminConfig) (IsAdminReader, error)) *cli.Command {
 	cmd := &cli.Command{
 		Name:      "is-admin",
-		Usage:     "user admin is-admin --account-address <AccountAddress> --caller-address <CallerAddress>",
+		Usage:     "user admin is-admin --account-address <AccountAddress> --admin-address <AdminAddress>",
 		UsageText: "Checks if a user is an admin.",
 		Description: `
 		Checks if a user is an admin.
@@ -133,7 +133,7 @@ func IsAdminFlags() []cli.Flag {
 	cmdFlags := []cli.Flag{
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
-		&CallerAddressFlag,
+		&AdminAddressFlag,
 		&PermissionControllerAddressFlag,
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,

--- a/pkg/user/admin/is_admin_test.go
+++ b/pkg/user/admin/is_admin_test.go
@@ -44,7 +44,7 @@ func TestIsAdminCmd_Success(t *testing.T) {
 		"TestIsAdminCmd_Success",
 		"is-admin",
 		"--account-address", "0xabcdef1234567890abcdef1234567890abcdef12",
-		"--caller-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--admin-address", "0x1234567890abcdef1234567890abcdef12345678",
 		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
 		"--network", "holesky",
 	}
@@ -63,7 +63,7 @@ func TestIsAdminCmd_NotAdmin(t *testing.T) {
 		"TestIsAdminCmd_NotAdmin",
 		"is-admin",
 		"--account-address", "0xabcdef1234567890abcdef1234567890abcdef12",
-		"--caller-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--admin-address", "0x1234567890abcdef1234567890abcdef12345678",
 		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
 		"--network", "holesky",
 	}
@@ -85,7 +85,7 @@ func TestIsAdminCmd_GeneratorError(t *testing.T) {
 		"TestIsAdminCmd_GeneratorError",
 		"is-admin",
 		"--account-address", "0xabcdef1234567890abcdef1234567890abcdef12",
-		"--caller-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--admin-address", "0x1234567890abcdef1234567890abcdef12345678",
 		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
 		"--network", "holesky",
 	}
@@ -106,7 +106,7 @@ func TestIsAdminCmd_IsAdminError(t *testing.T) {
 		"TestIsAdminCmd_IsAdminError",
 		"is-admin",
 		"--account-address", "0xabcdef1234567890abcdef1234567890abcdef12",
-		"--caller-address", "0x1234567890abcdef1234567890abcdef12345678",
+		"--admin-address", "0x1234567890abcdef1234567890abcdef12345678",
 		"--eth-rpc-url", "https://ethereum-holesky.publicnode.com/",
 		"--network", "holesky",
 	}

--- a/pkg/user/appointee/appointee.go
+++ b/pkg/user/appointee/appointee.go
@@ -21,11 +21,11 @@ func AppointeeCmd(prompter utils.Prompter) *cli.Command {
 		},
 		Subcommands: []*cli.Command{
 			BatchSetCmd(),
-			canCallCmd(generateUserCanCallReader),
-			ListCmd(generateListUsersReader),
-			ListPermissionsCmd(generateListUserPermissionsReader),
-			RemoveCmd(generateRemoveUserPermissionWriter(prompter)),
-			SetCmd(generateSetUserPermissionWriter(prompter)),
+			canCallCmd(generateCanCallReader),
+			ListCmd(generateListAppointeesReader),
+			ListPermissionsCmd(generateListAppointeePermissionsReader),
+			RemoveCmd(generateRemoveAppointeePermissionWriter(prompter)),
+			SetCmd(generateSetAppointeePermissionWriter(prompter)),
 		},
 	}
 

--- a/pkg/user/appointee/can_call.go
+++ b/pkg/user/appointee/can_call.go
@@ -17,23 +17,23 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-type UserCanCallReader interface {
-	UserCanCall(
+type CanCallReader interface {
+	CanCall(
 		ctx context.Context,
-		userAddress gethcommon.Address,
-		callerAddress gethcommon.Address,
+		accountAddress gethcommon.Address,
+		appointeeAddress gethcommon.Address,
 		target gethcommon.Address,
 		selector [4]byte,
 	) (bool, error)
 }
 
-func canCallCmd(readerGenerator func(logging.Logger, *canCallConfig) (UserCanCallReader, error)) *cli.Command {
+func canCallCmd(readerGenerator func(logging.Logger, *canCallConfig) (CanCallReader, error)) *cli.Command {
 	cmd := &cli.Command{
 		Name:      "can-call",
-		Usage:     "user appointee can-call --account-address <AccountsAddress> --caller-address <CallerAddress> --taget-address <TargetAddress> --selector <Selector>",
-		UsageText: "Checks if a user has a specific permission.",
+		Usage:     "user appointee can-call --account-address <AccountsAddress> --appointee-address <AppointeeAddress> --target-address <TargetAddress> --selector <Selector>",
+		UsageText: "Checks if an appointee has a specific permission.",
 		Description: `
-		Checks if a user has a specific permission.
+		Checks if an appointee has a specific permission.
 		`,
 		Action: func(c *cli.Context) error {
 			return canCall(c, readerGenerator)
@@ -45,11 +45,11 @@ func canCallCmd(readerGenerator func(logging.Logger, *canCallConfig) (UserCanCal
 	return cmd
 }
 
-func canCall(cliCtx *cli.Context, generator func(logging.Logger, *canCallConfig) (UserCanCallReader, error)) error {
+func canCall(cliCtx *cli.Context, generator func(logging.Logger, *canCallConfig) (CanCallReader, error)) error {
 	ctx := cliCtx.Context
 	logger := common.GetLogger(cliCtx)
 
-	config, err := readAndValidateUserConfig(cliCtx, logger)
+	config, err := readAndValidateCanCallConfig(cliCtx, logger)
 	if err != nil {
 		return eigenSdkUtils.WrapError("failed to read and validate user can call config", err)
 	}
@@ -59,15 +59,15 @@ func canCall(cliCtx *cli.Context, generator func(logging.Logger, *canCallConfig)
 		return err
 	}
 
-	result, err := elReader.UserCanCall(ctx, config.UserAddress, config.CallerAddress, config.Target, config.Selector)
+	result, err := elReader.CanCall(ctx, config.AppointeeAddress, config.AccountAddress, config.Target, config.Selector)
 	fmt.Printf("CanCall Result: %v\n", result)
-	fmt.Printf("Selector, Target and User: %s, %x, %s\n", config.Target, string(config.Selector[:]), config.UserAddress)
+	fmt.Printf("Selector, Target and Appointee: %s, %x, %s\n", config.Target, string(config.Selector[:]), config.AppointeeAddress)
 	return err
 }
 
-func readAndValidateUserConfig(cliContext *cli.Context, logger logging.Logger) (*canCallConfig, error) {
-	userAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
-	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
+func readAndValidateCanCallConfig(cliContext *cli.Context, logger logging.Logger) (*canCallConfig, error) {
+	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
+	appointeeAddress := gethcommon.HexToAddress(cliContext.String(AppointeeAddressFlag.Name))
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -103,8 +103,8 @@ func readAndValidateUserConfig(cliContext *cli.Context, logger logging.Logger) (
 	return &canCallConfig{
 		Network:                  network,
 		RPCUrl:                   ethRpcUrl,
-		UserAddress:              userAddress,
-		CallerAddress:            callerAddress,
+		AccountAddress:           accountAddress,
+		AppointeeAddress:         appointeeAddress,
 		Target:                   target,
 		Selector:                 selectorBytes,
 		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
@@ -113,10 +113,10 @@ func readAndValidateUserConfig(cliContext *cli.Context, logger logging.Logger) (
 	}, nil
 }
 
-func generateUserCanCallReader(
+func generateCanCallReader(
 	logger logging.Logger,
 	config *canCallConfig,
-) (UserCanCallReader, error) {
+) (CanCallReader, error) {
 	ethClient, err := ethclient.Dial(config.RPCUrl)
 	if err != nil {
 		return nil, eigenSdkUtils.WrapError("failed to create new eth client", err)
@@ -134,7 +134,7 @@ func generateUserCanCallReader(
 func canCallFlags() []cli.Flag {
 	cmdFlags := []cli.Flag{
 		&AccountAddressFlag,
-		&CallerAddressFlag,
+		&AppointeeAddressFlag,
 		&TargetAddressFlag,
 		&SelectorFlag,
 		&PermissionControllerAddressFlag,

--- a/pkg/user/appointee/can_call.go
+++ b/pkg/user/appointee/can_call.go
@@ -61,7 +61,12 @@ func canCall(cliCtx *cli.Context, generator func(logging.Logger, *canCallConfig)
 
 	result, err := elReader.CanCall(ctx, config.AppointeeAddress, config.AccountAddress, config.Target, config.Selector)
 	fmt.Printf("CanCall Result: %v\n", result)
-	fmt.Printf("Selector, Target and Appointee: %s, %x, %s\n", config.Target, string(config.Selector[:]), config.AppointeeAddress)
+	fmt.Printf(
+		"Selector, Target and Appointee: %s, %x, %s\n",
+		config.Target,
+		string(config.Selector[:]),
+		config.AppointeeAddress,
+	)
 	return err
 }
 

--- a/pkg/user/appointee/can_call_test.go
+++ b/pkg/user/appointee/can_call_test.go
@@ -14,8 +14,8 @@ import (
 type mockElChainReader struct {
 	canCallFunc func(
 		ctx context.Context,
-		userAddress gethcommon.Address,
-		callerAddress gethcommon.Address,
+		accountAddress gethcommon.Address,
+		appointeeAddress gethcommon.Address,
 		target gethcommon.Address,
 		selector [4]byte,
 	) (bool, error)
@@ -23,7 +23,7 @@ type mockElChainReader struct {
 
 func newMockElChainReader() mockElChainReader {
 	return mockElChainReader{
-		canCallFunc: func(ctx context.Context, userAddress, callerAddress, target gethcommon.Address, selector [4]byte) (bool, error) {
+		canCallFunc: func(ctx context.Context, accountAddress, appointeeAddress, target gethcommon.Address, selector [4]byte) (bool, error) {
 			return true, nil
 		},
 	}
@@ -31,19 +31,19 @@ func newMockElChainReader() mockElChainReader {
 
 func newErrorMockElChainReader(expectedError string) mockElChainReader {
 	return mockElChainReader{
-		canCallFunc: func(ctx context.Context, userAddress, callerAddress, target gethcommon.Address, selector [4]byte) (bool, error) {
+		canCallFunc: func(ctx context.Context, accountAddress, appointeeAddress, target gethcommon.Address, selector [4]byte) (bool, error) {
 			return false, errors.New(expectedError)
 		},
 	}
 }
 
-func (m *mockElChainReader) UserCanCall(
+func (m *mockElChainReader) CanCall(
 	ctx context.Context,
-	userAddress, callerAddress,
+	accountAddress, appointeeAddress,
 	target gethcommon.Address,
 	selector [4]byte,
 ) (bool, error) {
-	return m.canCallFunc(ctx, userAddress, callerAddress, target, selector)
+	return m.canCallFunc(ctx, accountAddress, appointeeAddress, target, selector)
 }
 
 func TestCanCallCmd_Success(t *testing.T) {
@@ -54,7 +54,7 @@ func TestCanCallCmd_Success(t *testing.T) {
 		"TestCanCallCmd_Success",
 		"can-call",
 		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
-		"--caller-address", "0x9876543210fedcba9876543210fedcba98765432",
+		"--appointee-address", "0x9876543210fedcba9876543210fedcba98765432",
 		"--target-address", "0xabcdef1234567890abcdef1234567890abcdef12",
 		"--selector", "0x1A2B3C4D",
 		"--network", "holesky",
@@ -66,22 +66,22 @@ func TestCanCallCmd_Success(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCanCallCmd_UserCanCallError(t *testing.T) {
+func TestCanCallCmd_CanCallError(t *testing.T) {
 	errString := "Error while executing call from reader"
 	mockReader := newErrorMockElChainReader(errString)
 
 	app := cli.NewApp()
 	app.Commands = []*cli.Command{
-		canCallCmd(func(logger logging.Logger, config *canCallConfig) (UserCanCallReader, error) {
-			return UserCanCallReader(&mockReader), nil
+		canCallCmd(func(logger logging.Logger, config *canCallConfig) (CanCallReader, error) {
+			return CanCallReader(&mockReader), nil
 		}),
 	}
 
 	args := []string{
-		"TestCanCallCmd_UserCanCallError",
+		"TestCanCallCmd_CanCallError",
 		"can-call",
 		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
-		"--caller-address", "0x9876543210fedcba9876543210fedcba98765432",
+		"--appointee-address", "0x9876543210fedcba9876543210fedcba98765432",
 		"--target-address", "0xabcdef1234567890abcdef1234567890abcdef12",
 		"--selector", "0x1A2B3C4D",
 		"--network", "holesky",
@@ -102,7 +102,7 @@ func TestCanCallCmd_InvalidSelector(t *testing.T) {
 		"TestCanCallCmd_InvalidSelector",
 		"can-call",
 		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
-		"--caller-address", "0x9876543210fedcba9876543210fedcba98765432",
+		"--appointee-address", "0x9876543210fedcba9876543210fedcba98765432",
 		"--target-address", "0xabcdef1234567890abcdef1234567890abcdef12",
 		"--selector", "incorrect-format",
 		"--permission-controller-address", "0xe4dB7125ef7a9D99F809B6b7788f75c8D84d8455",
@@ -117,7 +117,7 @@ func TestCanCallCmd_InvalidSelector(t *testing.T) {
 		"TestCanCallCmd_InvalidSelector",
 		"can-call",
 		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
-		"--caller-address", "0x9876543210fedcba9876543210fedcba98765432",
+		"--appointee-address", "0x9876543210fedcba9876543210fedcba98765432",
 		"--target-address", "0xabcdef1234567890abcdef1234567890abcdef12",
 		"--selector", "0xincorrect-format",
 		"--permission-controller-address", "0xe4dB7125ef7a9D99F809B6b7788f75c8D84d8455",
@@ -129,9 +129,9 @@ func TestCanCallCmd_InvalidSelector(t *testing.T) {
 	assert.Contains(t, err.Error(), "selector must be a 4-byte hex string prefixed with '0x'")
 }
 
-func generateMockReader() func(logger logging.Logger, config *canCallConfig) (UserCanCallReader, error) {
-	return func(logger logging.Logger, config *canCallConfig) (UserCanCallReader, error) {
+func generateMockReader() func(logger logging.Logger, config *canCallConfig) (CanCallReader, error) {
+	return func(logger logging.Logger, config *canCallConfig) (CanCallReader, error) {
 		mockReader := newMockElChainReader()
-		return UserCanCallReader(&mockReader), nil
+		return CanCallReader(&mockReader), nil
 	}
 }

--- a/pkg/user/appointee/flags.go
+++ b/pkg/user/appointee/flags.go
@@ -15,12 +15,6 @@ var (
 		Usage:   "The Ethereum address of the user. Example: --appointee-address \"0x...\"",
 		EnvVars: []string{"APPOINTEE_ADDRESS"},
 	}
-	CallerAddressFlag = cli.StringFlag{
-		Name:    "caller-address",
-		Aliases: []string{"ca"},
-		Usage:   "The Ethereum address of the caller. Example: --caller-address \"0x...\"",
-		EnvVars: []string{"CALLER_ADDRESS"},
-	}
 	SelectorFlag = cli.StringFlag{
 		Name:    "selector",
 		Aliases: []string{"s"},

--- a/pkg/user/appointee/list.go
+++ b/pkg/user/appointee/list.go
@@ -18,22 +18,22 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-type ListUsersReader interface {
-	ListUsers(
+type ListAppointeesReader interface {
+	ListAppointees(
 		ctx context.Context,
-		userAddress gethcommon.Address,
+		accountAddress gethcommon.Address,
 		target gethcommon.Address,
 		selector [4]byte,
 	) ([]gethcommon.Address, error)
 }
 
-func ListCmd(readerGenerator func(logging.Logger, *listUsersConfig) (ListUsersReader, error)) *cli.Command {
+func ListCmd(readerGenerator func(logging.Logger, *listAppointeesConfig) (ListAppointeesReader, error)) *cli.Command {
 	listCmd := &cli.Command{
 		Name:      "list",
 		Usage:     "user appointee list --account-address <AccountAddress> --target-address <TargetAddress> --selector <Selector>",
-		UsageText: "Lists all appointed users for an account with the provided permissions.",
+		UsageText: "Lists all appointed addresses for an account with the provided permissions.",
 		Description: `
-		Lists all appointed users for an account with the provided permissions.
+		Lists all appointed addresses for an account with the provided permissions.
 		`,
 		Action: func(c *cli.Context) error {
 			return listAppointees(c, readerGenerator)
@@ -47,12 +47,12 @@ func ListCmd(readerGenerator func(logging.Logger, *listUsersConfig) (ListUsersRe
 
 func listAppointees(
 	cliCtx *cli.Context,
-	generator func(logging.Logger, *listUsersConfig) (ListUsersReader, error),
+	generator func(logging.Logger, *listAppointeesConfig) (ListAppointeesReader, error),
 ) error {
 	ctx := cliCtx.Context
 	logger := common.GetLogger(cliCtx)
 
-	config, err := readAndValidateListUsersConfig(cliCtx, logger)
+	config, err := readAndValidateListAppointeesConfig(cliCtx, logger)
 	if err != nil {
 		return eigenSdkUtils.WrapError("failed to read and validate user appointee list config", err)
 	}
@@ -62,30 +62,30 @@ func listAppointees(
 		return err
 	}
 
-	users, err := elReader.ListUsers(ctx, config.UserAddress, config.Target, config.Selector)
+	appointees, err := elReader.ListAppointees(ctx, config.AccountAddress, config.Target, config.Selector)
 	if err != nil {
 		return err
 	}
-	printResults(config, users)
+	printResults(config, appointees)
 	return nil
 }
 
-func printResults(config *listUsersConfig, users []gethcommon.Address) {
+func printResults(config *listAppointeesConfig, appointees []gethcommon.Address) {
 	fmt.Printf(
-		"Selector, Target and Appointer: %s, %x, %s",
+		"Target, Selector and Appointer: %s, %x, %s",
 		config.Target,
 		string(config.Selector[:]),
-		config.UserAddress,
+		config.AccountAddress,
 	)
-	fmt.Println(strings.Repeat("=", 80))
+	fmt.Println(strings.Repeat("=", 60))
 
-	for _, user := range users {
-		fmt.Printf("User Id: 0x%b\n", user)
+	for _, appointee := range appointees {
+		fmt.Printf("Appointee address: %s\n", appointee)
 	}
 }
 
-func readAndValidateListUsersConfig(cliContext *cli.Context, logger logging.Logger) (*listUsersConfig, error) {
-	userAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
+func readAndValidateListAppointeesConfig(cliContext *cli.Context, logger logging.Logger) (*listAppointeesConfig, error) {
+	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -119,10 +119,10 @@ func readAndValidateListUsersConfig(cliContext *cli.Context, logger logging.Logg
 		permissionManagerAddress,
 	)
 
-	return &listUsersConfig{
+	return &listAppointeesConfig{
 		Network:                  network,
 		RPCUrl:                   ethRpcUrl,
-		UserAddress:              userAddress,
+		AccountAddress:           accountAddress,
 		Target:                   target,
 		Selector:                 selectorBytes,
 		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
@@ -131,7 +131,7 @@ func readAndValidateListUsersConfig(cliContext *cli.Context, logger logging.Logg
 	}, nil
 }
 
-func generateListUsersReader(logger logging.Logger, config *listUsersConfig) (ListUsersReader, error) {
+func generateListAppointeesReader(logger logging.Logger, config *listAppointeesConfig) (ListAppointeesReader, error) {
 	ethClient, err := ethclient.Dial(config.RPCUrl)
 	if err != nil {
 		return nil, eigenSdkUtils.WrapError("failed to create new eth client", err)

--- a/pkg/user/appointee/list.go
+++ b/pkg/user/appointee/list.go
@@ -84,7 +84,10 @@ func printResults(config *listAppointeesConfig, appointees []gethcommon.Address)
 	}
 }
 
-func readAndValidateListAppointeesConfig(cliContext *cli.Context, logger logging.Logger) (*listAppointeesConfig, error) {
+func readAndValidateListAppointeesConfig(
+	cliContext *cli.Context,
+	logger logging.Logger,
+) (*listAppointeesConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)

--- a/pkg/user/appointee/list_permissions_test.go
+++ b/pkg/user/appointee/list_permissions_test.go
@@ -15,43 +15,43 @@ import (
 type mockListPermissionsReader struct {
 	listPermissionsFunc func(
 		ctx context.Context,
-		appointed gethcommon.Address,
-		userAddress gethcommon.Address,
+		accountAddress gethcommon.Address,
+		appointeeAddress gethcommon.Address,
 	) ([]gethcommon.Address, [][4]byte, error)
 }
 
 func newMockListPermissionsReader(
-	users []gethcommon.Address,
+	appointeeAddresses []gethcommon.Address,
 	permissions [][4]byte,
 	err error,
 ) *mockListPermissionsReader {
 	return &mockListPermissionsReader{
-		listPermissionsFunc: func(ctx context.Context, appointed, userAddress gethcommon.Address) ([]gethcommon.Address, [][4]byte, error) {
-			return users, permissions, err
+		listPermissionsFunc: func(ctx context.Context, accountAddress, appointeeAddress gethcommon.Address) ([]gethcommon.Address, [][4]byte, error) {
+			return appointeeAddresses, permissions, err
 		},
 	}
 }
 
-func (m *mockListPermissionsReader) ListUserPermissions(
+func (m *mockListPermissionsReader) ListAppointeePermissions(
 	ctx context.Context,
-	appointed gethcommon.Address,
-	userAddress gethcommon.Address,
+	accountAddress gethcommon.Address,
+	appointeeAddress gethcommon.Address,
 ) ([]gethcommon.Address, [][4]byte, error) {
-	return m.listPermissionsFunc(ctx, appointed, userAddress)
+	return m.listPermissionsFunc(ctx, accountAddress, appointeeAddress)
 }
 
 func generateMockListPermissionsReader(
-	users []gethcommon.Address,
+	appointeeAddresses []gethcommon.Address,
 	permissions [][4]byte,
 	err error,
-) func(logging.Logger, *listUserPermissionsConfig) (PermissionsReader, error) {
-	return func(logger logging.Logger, config *listUserPermissionsConfig) (PermissionsReader, error) {
-		return newMockListPermissionsReader(users, permissions, err), nil
+) func(logging.Logger, *listAppointeePermissionsConfig) (PermissionsReader, error) {
+	return func(logger logging.Logger, config *listAppointeePermissionsConfig) (PermissionsReader, error) {
+		return newMockListPermissionsReader(appointeeAddresses, permissions, err), nil
 	}
 }
 
 func TestListPermissions_Success(t *testing.T) {
-	expectedUsers := []gethcommon.Address{
+	expectedAppointees := []gethcommon.Address{
 		gethcommon.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
 	}
 	expectedPermissions := [][4]byte{
@@ -60,7 +60,7 @@ func TestListPermissions_Success(t *testing.T) {
 
 	app := cli.NewApp()
 	app.Commands = []*cli.Command{
-		ListPermissionsCmd(generateMockListPermissionsReader(expectedUsers, expectedPermissions, nil)),
+		ListPermissionsCmd(generateMockListPermissionsReader(expectedAppointees, expectedPermissions, nil)),
 	}
 
 	args := []string{

--- a/pkg/user/appointee/list_test.go
+++ b/pkg/user/appointee/list_test.go
@@ -12,49 +12,50 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-type mockListUsersReader struct {
-	listUsersFunc func(
+type mockListAppointeesReader struct {
+	listAppointeesFunc func(
 		ctx context.Context,
-		userAddress gethcommon.Address,
+		accountAddress gethcommon.Address,
 		target gethcommon.Address,
 		selector [4]byte,
 	) ([]gethcommon.Address, error)
 }
 
-func newMockListUsersReader(users []gethcommon.Address, err error) *mockListUsersReader {
-	return &mockListUsersReader{
-		listUsersFunc: func(ctx context.Context, userAddress, target gethcommon.Address, selector [4]byte) ([]gethcommon.Address, error) {
-			return users, err
+func newMockListAppointeesReader(appointeeAddresses []gethcommon.Address, err error) *mockListAppointeesReader {
+	return &mockListAppointeesReader{
+		listAppointeesFunc: func(ctx context.Context, accountAddress, target gethcommon.Address, selector [4]byte) ([]gethcommon.Address, error) {
+			return appointeeAddresses, err
 		},
 	}
 }
 
-func (m *mockListUsersReader) ListUsers(
+func (m *mockListAppointeesReader) ListAppointees(
 	ctx context.Context,
-	userAddress, target gethcommon.Address,
+	accountAddress,
+	target gethcommon.Address,
 	selector [4]byte,
 ) ([]gethcommon.Address, error) {
-	return m.listUsersFunc(ctx, userAddress, target, selector)
+	return m.listAppointeesFunc(ctx, accountAddress, target, selector)
 }
 
 func generateMockListReader(
-	users []gethcommon.Address,
+	appointeeAddresses []gethcommon.Address,
 	err error,
-) func(logging.Logger, *listUsersConfig) (ListUsersReader, error) {
-	return func(logger logging.Logger, config *listUsersConfig) (ListUsersReader, error) {
-		return newMockListUsersReader(users, err), nil
+) func(logging.Logger, *listAppointeesConfig) (ListAppointeesReader, error) {
+	return func(logger logging.Logger, config *listAppointeesConfig) (ListAppointeesReader, error) {
+		return newMockListAppointeesReader(appointeeAddresses, err), nil
 	}
 }
 
 func TestListAppointees_Success(t *testing.T) {
-	expectedUsers := []gethcommon.Address{
+	expectedAppointees := []gethcommon.Address{
 		gethcommon.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
 		gethcommon.HexToAddress("0x9876543210fedcba9876543210fedcba98765432"),
 	}
 
 	app := cli.NewApp()
 	app.Commands = []*cli.Command{
-		ListCmd(generateMockListReader(expectedUsers, nil)),
+		ListCmd(generateMockListReader(expectedAppointees, nil)),
 	}
 
 	args := []string{
@@ -114,14 +115,14 @@ func TestListAppointees_InvalidSelector(t *testing.T) {
 	assert.Contains(t, err.Error(), "selector must be a 4-byte hex string prefixed with '0x'")
 }
 
-func TestListAppointees_NoUsers(t *testing.T) {
+func TestListAppointees_NoAppointees(t *testing.T) {
 	app := cli.NewApp()
 	app.Commands = []*cli.Command{
 		ListCmd(generateMockListReader([]gethcommon.Address{}, nil)),
 	}
 
 	args := []string{
-		"TestListAppointees_NoUsers",
+		"TestListAppointees_NoAppointees",
 		"list",
 		"--account-address", "0x1234567890abcdef1234567890abcdef12345678",
 		"--target-address", "0xabcdef1234567890abcdef1234567890abcdef12",

--- a/pkg/user/appointee/remove_test.go
+++ b/pkg/user/appointee/remove_test.go
@@ -13,20 +13,20 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-type mockRemoveUserPermissionWriter struct {
+type mockRemoveAppointeePermissionWriter struct {
 	removePermissionFunc func(ctx context.Context, request elcontracts.RemovePermissionRequest) (*gethtypes.Receipt, error)
 }
 
-func (m *mockRemoveUserPermissionWriter) RemovePermission(
+func (m *mockRemoveAppointeePermissionWriter) RemovePermission(
 	ctx context.Context,
 	request elcontracts.RemovePermissionRequest,
 ) (*gethtypes.Receipt, error) {
 	return m.removePermissionFunc(ctx, request)
 }
 
-func generateMockRemoveWriter(err error) func(logging.Logger, *removeConfig) (RemoveUserPermissionWriter, error) {
-	return func(logger logging.Logger, config *removeConfig) (RemoveUserPermissionWriter, error) {
-		return &mockRemoveUserPermissionWriter{
+func generateMockRemoveWriter(err error) func(logging.Logger, *removeConfig) (RemoveAppointeePermissionWriter, error) {
+	return func(logger logging.Logger, config *removeConfig) (RemoveAppointeePermissionWriter, error) {
+		return &mockRemoveAppointeePermissionWriter{
 			removePermissionFunc: func(ctx context.Context, request elcontracts.RemovePermissionRequest) (*gethtypes.Receipt, error) {
 				return &gethtypes.Receipt{}, err
 			},
@@ -60,7 +60,7 @@ func TestRemoveCmd_GeneratorError(t *testing.T) {
 	expectedError := "failed to create permission writer"
 	app := cli.NewApp()
 	app.Commands = []*cli.Command{
-		RemoveCmd(func(logger logging.Logger, config *removeConfig) (RemoveUserPermissionWriter, error) {
+		RemoveCmd(func(logger logging.Logger, config *removeConfig) (RemoveAppointeePermissionWriter, error) {
 			return nil, errors.New(expectedError)
 		}),
 	}

--- a/pkg/user/appointee/set_test.go
+++ b/pkg/user/appointee/set_test.go
@@ -13,20 +13,20 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-type mockSetUserPermissionWriter struct {
+type mockSetAppointeePermissionWriter struct {
 	setPermissionFunc func(ctx context.Context, request elcontracts.SetPermissionRequest) (*gethtypes.Receipt, error)
 }
 
-func (m *mockSetUserPermissionWriter) SetPermission(
+func (m *mockSetAppointeePermissionWriter) SetPermission(
 	ctx context.Context,
 	request elcontracts.SetPermissionRequest,
 ) (*gethtypes.Receipt, error) {
 	return m.setPermissionFunc(ctx, request)
 }
 
-func generateMockSetWriter(err error) func(logging.Logger, *setConfig) (SetUserPermissionWriter, error) {
-	return func(logger logging.Logger, config *setConfig) (SetUserPermissionWriter, error) {
-		return &mockSetUserPermissionWriter{
+func generateMockSetWriter(err error) func(logging.Logger, *setConfig) (SetAppointeePermissionWriter, error) {
+	return func(logger logging.Logger, config *setConfig) (SetAppointeePermissionWriter, error) {
+		return &mockSetAppointeePermissionWriter{
 			setPermissionFunc: func(ctx context.Context, request elcontracts.SetPermissionRequest) (*gethtypes.Receipt, error) {
 				return &gethtypes.Receipt{}, err
 			},
@@ -60,7 +60,7 @@ func TestSetCmd_GeneratorError(t *testing.T) {
 	expectedError := "failed to create permission writer"
 	app := cli.NewApp()
 	app.Commands = []*cli.Command{
-		SetCmd(func(logger logging.Logger, config *setConfig) (SetUserPermissionWriter, error) {
+		SetCmd(func(logger logging.Logger, config *setConfig) (SetAppointeePermissionWriter, error) {
 			return nil, errors.New(expectedError)
 		}),
 	}

--- a/pkg/user/appointee/types.go
+++ b/pkg/user/appointee/types.go
@@ -10,8 +10,8 @@ import (
 type canCallConfig struct {
 	Network                  string
 	RPCUrl                   string
-	UserAddress              gethcommon.Address
-	CallerAddress            gethcommon.Address
+	AccountAddress           gethcommon.Address
+	AppointeeAddress         gethcommon.Address
 	Target                   gethcommon.Address
 	Selector                 [4]byte
 	PermissionManagerAddress gethcommon.Address
@@ -19,11 +19,10 @@ type canCallConfig struct {
 	Environment              string
 }
 
-type listUsersConfig struct {
+type listAppointeesConfig struct {
 	Network                  string
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
-	UserAddress              gethcommon.Address
 	Target                   gethcommon.Address
 	Selector                 [4]byte
 	PermissionManagerAddress gethcommon.Address
@@ -31,11 +30,11 @@ type listUsersConfig struct {
 	Environment              string
 }
 
-type listUserPermissionsConfig struct {
+type listAppointeePermissionsConfig struct {
 	Network                  string
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
-	UserAddress              gethcommon.Address
+	AppointeeAddress         gethcommon.Address
 	PermissionManagerAddress gethcommon.Address
 	ChainID                  *big.Int
 	Environment              string
@@ -45,7 +44,7 @@ type removeConfig struct {
 	Network                  string
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
-	UserAddress              gethcommon.Address
+	AppointeeAddress         gethcommon.Address
 	Target                   gethcommon.Address
 	SignerConfig             types.SignerConfig
 	Selector                 [4]byte
@@ -58,7 +57,7 @@ type setConfig struct {
 	Network                  string
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
-	UserAddress              gethcommon.Address
+	AppointeeAddress         gethcommon.Address
 	Target                   gethcommon.Address
 	SignerConfig             types.SignerConfig
 	Selector                 [4]byte


### PR DESCRIPTION
Refactoring user commands to remove user nomenclature and replacing with appointee.

### What Changed?
 - replacing user nomenclature with appointee
