### PR TITLE
feat: get/set operator PI split commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Layr-Labs/eigenlayer-contracts v0.3.2-mainnet-rewards
 	github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.12
 	github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-5c11a259293e
-	github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241211225219-79336bf6e886
+	github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241212190947-9985122d81fe
 	github.com/blang/semver/v4 v4.0.0
 	github.com/consensys/gnark-crypto v0.12.1
 	github.com/ethereum/go-ethereum v1.14.5

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-
 github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-5c11a259293e/go.mod h1:T7tYN8bTdca2pkMnz9G2+ZwXYWw5gWqQUIu4KLgC/vM=
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241211225219-79336bf6e886 h1:+7AijqdfRXdDc3zvj02Alqsk6Qd3owvlqPYQN1Hc1ME=
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241211225219-79336bf6e886/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
+github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241212190947-9985122d81fe h1:FeXxapvtEbbTbEWsrcBTTzQ2u2quGJ9HNYQVSk5JZ8g=
+github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241212190947-9985122d81fe/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=

--- a/pkg/operator.go
+++ b/pkg/operator.go
@@ -20,6 +20,8 @@ func OperatorCmd(p utils.Prompter) *cli.Command {
 			operator.GetApprovalCmd(p),
 			operator.SetOperatorSplitCmd(p),
 			operator.GetOperatorSplitCmd(p),
+			operator.GetOperatorPISplitCmd(p),
+			operator.SetOperatorPISplitCmd(p),
 		},
 	}
 

--- a/pkg/operator/get_operator_pi_split.go
+++ b/pkg/operator/get_operator_pi_split.go
@@ -1,0 +1,39 @@
+package operator
+
+import (
+	"sort"
+
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/operator/split"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/rewards"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
+	"github.com/urfave/cli/v2"
+)
+
+func GetOperatorPISplitCmd(p utils.Prompter) *cli.Command {
+	var operatorSplitCmd = &cli.Command{
+		Name:  "get-pi-split",
+		Usage: "Get programmatic incentives rewards split",
+		Action: func(cCtx *cli.Context) error {
+			return GetOperatorSplit(cCtx, true)
+		},
+		After: telemetry.AfterRunAction(),
+		Flags: getGetOperatorPISplitFlags(),
+	}
+
+	return operatorSplitCmd
+}
+
+func getGetOperatorPISplitFlags() []cli.Flag {
+	baseFlags := []cli.Flag{
+		&flags.NetworkFlag,
+		&flags.ETHRpcUrlFlag,
+		&flags.OperatorAddressFlag,
+		&split.OperatorSplitFlag,
+		&rewards.RewardsCoordinatorAddressFlag,
+	}
+
+	sort.Sort(cli.FlagsByName(baseFlags))
+	return baseFlags
+}

--- a/pkg/operator/set_operator_pi_split.go
+++ b/pkg/operator/set_operator_pi_split.go
@@ -1,0 +1,44 @@
+package operator
+
+import (
+	"sort"
+
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/operator/split"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/rewards"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
+	"github.com/urfave/cli/v2"
+)
+
+func SetOperatorPISplitCmd(p utils.Prompter) *cli.Command {
+	var operatorSplitCmd = &cli.Command{
+		Name:  "set-pi-split",
+		Usage: "Set operator programmatic incentives split",
+		Action: func(cCtx *cli.Context) error {
+			return SetOperatorSplit(cCtx, p, true)
+		},
+		After: telemetry.AfterRunAction(),
+		Flags: getSetOperatorPISplitFlags(),
+	}
+
+	return operatorSplitCmd
+}
+
+func getSetOperatorPISplitFlags() []cli.Flag {
+	baseFlags := []cli.Flag{
+		&flags.NetworkFlag,
+		&flags.ETHRpcUrlFlag,
+		&flags.OperatorAddressFlag,
+		&split.OperatorSplitFlag,
+		&rewards.RewardsCoordinatorAddressFlag,
+		&flags.BroadcastFlag,
+		&flags.OutputTypeFlag,
+		&flags.OutputFileFlag,
+		&flags.SilentFlag,
+	}
+
+	allFlags := append(baseFlags, flags.GetSignerFlags()...)
+	sort.Sort(cli.FlagsByName(allFlags))
+	return allFlags
+}


### PR DESCRIPTION
Adds operator split command for rewards v2:
`./eigenlayer operator set-pi-split --operator-address 0x025246421e7247a729bbcff652c5cc1815ac6373 --avs-address 0xfF95c28C1c38bbb26EC7Ad0BAf7b17375Ff6315C --eth-rpc-url http://rpc-url --network holesky --split 1000 --broadcast`

Eigensdk has been updated to include getting / setting methods in https://github.com/Layr-Labs/eigensdk-go/pull/406

![Screenshot 2024-12-12 at 3 10 13 PM](https://github.com/user-attachments/assets/4290ae22-6d22-4c93-872c-1d311b19a004)

![Screenshot 2024-12-12 at 3 14 52 PM](https://github.com/user-attachments/assets/40e0abb5-7f47-4964-8e9c-71d365e1b5de)
