### PR TITLE
Adding caller-address to support arbitrary CLI signing address.

### DIFF
--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -76,6 +76,7 @@ func readAndValidateAcceptAdminConfig(
 	logger logging.Logger,
 ) (*acceptAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
+	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddress.Name))
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -98,6 +99,13 @@ func readAndValidateAcceptAdminConfig(
 			return nil, err
 		}
 	}
+	if common.IsEmptyString(callerAddress.String()) {
+		logger.Infof(
+			"Caller address not provided. Using account address (%s) as caller address",
+			accountAddress,
+		)
+		callerAddress = accountAddress
+	}
 
 	logger.Debugf(
 		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
@@ -111,6 +119,7 @@ func readAndValidateAcceptAdminConfig(
 		Network:                  network,
 		RPCUrl:                   ethRpcUrl,
 		AccountAddress:           accountAddress,
+		CallerAddress:            callerAddress,
 		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
 		SignerConfig:             *signerConfig,
 		ChainID:                  chainID,
@@ -144,7 +153,7 @@ func generateAcceptAdminWriter(
 			return nil, eigenSdkUtils.WrapError("failed to create new eth client", err)
 		}
 		return common.GetELWriter(
-			config.AccountAddress,
+			config.CallerAddress,
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{

--- a/pkg/user/admin/flags.go
+++ b/pkg/user/admin/flags.go
@@ -15,6 +15,13 @@ var (
 		Usage:   "user admin ... --admin-address \"0x...\"",
 		EnvVars: []string{"ADMIN_ADDRESS"},
 	}
+	CallerAddress = cli.StringFlag{
+		Name:    "caller-address",
+		Aliases: []string{"ca"},
+		Usage: "This is the address of the caller who is calling the contract function. \n" +
+			"If it is not provided, the account address will be used as the caller address",
+		EnvVars: []string{"CALLER_ADDRESS"},
+	}
 	PendingAdminAddressFlag = cli.StringFlag{
 		Name:    "pending-admin-address",
 		Aliases: []string{"paa"},

--- a/pkg/user/admin/types.go
+++ b/pkg/user/admin/types.go
@@ -49,6 +49,7 @@ type acceptAdminConfig struct {
 	Network                  string
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
+	CallerAddress            gethcommon.Address
 	PermissionManagerAddress gethcommon.Address
 	SignerConfig             types.SignerConfig
 	ChainID                  *big.Int

--- a/pkg/user/appointee/flags.go
+++ b/pkg/user/appointee/flags.go
@@ -15,6 +15,13 @@ var (
 		Usage:   "The Ethereum address of the user. Example: --appointee-address \"0x...\"",
 		EnvVars: []string{"APPOINTEE_ADDRESS"},
 	}
+	CallerAddressFlag = cli.StringFlag{
+		Name:    "caller-address",
+		Aliases: []string{"ca"},
+		Usage: "This is the address of the caller who is calling the contract function. \n" +
+			"If it is not provided, the account address will be used as the caller address",
+		EnvVars: []string{"CALLER_ADDRESS"},
+	}
 	SelectorFlag = cli.StringFlag{
 		Name:    "selector",
 		Aliases: []string{"s"},
@@ -26,12 +33,6 @@ var (
 		Aliases: []string{"ta"},
 		Usage:   "The contract address for managing permissions to protocol operations.",
 		EnvVars: []string{"TARGET_ADDRESS"},
-	}
-	BatchSetFileFlag = cli.StringFlag{
-		Name:    "batch-set-file",
-		Aliases: []string{"bsf"},
-		Usage:   "A YAML file for executing a batch of set permission operations.",
-		EnvVars: []string{"BATCH_SET_FILE"},
 	}
 	PermissionControllerAddressFlag = cli.StringFlag{
 		Name:    "permission-controller-address",

--- a/pkg/user/appointee/types.go
+++ b/pkg/user/appointee/types.go
@@ -45,6 +45,7 @@ type removeConfig struct {
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
 	AppointeeAddress         gethcommon.Address
+	CallerAddress            gethcommon.Address
 	Target                   gethcommon.Address
 	SignerConfig             types.SignerConfig
 	Selector                 [4]byte
@@ -61,6 +62,7 @@ type setConfig struct {
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
 	AppointeeAddress         gethcommon.Address
+	CallerAddress            gethcommon.Address
 	Target                   gethcommon.Address
 	SignerConfig             types.SignerConfig
 	Selector                 [4]byte


### PR DESCRIPTION
Adding caller-address to support arbitrary CLI signing address.

### What Changed?
Signers of this command can be arbitrary. The `caller-address` adds support for this use.
