### PR TITLE
Adding caller-address to user admin commands to specify arbitrary caller with appointed permissions

### DIFF
--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -72,7 +72,7 @@ func readAndValidateAcceptAdminConfig(
 	logger logging.Logger,
 ) (*acceptAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
-	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddress.Name))
+	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -127,6 +127,7 @@ func acceptFlags() []cli.Flag {
 	cmdFlags := []cli.Flag{
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
+		&CallerAddressFlag,
 		&PermissionControllerAddressFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,

--- a/pkg/user/admin/add_pending.go
+++ b/pkg/user/admin/add_pending.go
@@ -77,11 +77,19 @@ func readAndValidateAddPendingAdminConfig(
 ) (*addPendingAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	adminAddress := gethcommon.HexToAddress(cliContext.String(AdminAddressFlag.Name))
+	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
+	}
+	if common.IsEmptyString(callerAddress.String()) {
+		logger.Infof(
+			"Caller address not provided. Using account address (%s) as caller address",
+			accountAddress,
+		)
+		callerAddress = accountAddress
 	}
 	signerConfig, err := common.GetSignerConfig(cliContext, logger)
 	if err != nil {
@@ -113,6 +121,7 @@ func readAndValidateAddPendingAdminConfig(
 		RPCUrl:                   ethRpcUrl,
 		AccountAddress:           accountAddress,
 		AdminAddress:             adminAddress,
+		CallerAddress:            callerAddress,
 		SignerConfig:             *signerConfig,
 		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
 		ChainID:                  chainID,
@@ -129,7 +138,7 @@ func generateAddPendingAdminWriter(
 			return nil, eigenSdkUtils.WrapError("failed to create new eth client", err)
 		}
 		return common.GetELWriter(
-			config.AccountAddress,
+			config.CallerAddress,
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
@@ -147,6 +156,7 @@ func addPendingFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AdminAddressFlag,
+		&CallerAddressFlag,
 		&PermissionControllerAddressFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,

--- a/pkg/user/admin/flags.go
+++ b/pkg/user/admin/flags.go
@@ -15,7 +15,7 @@ var (
 		Usage:   "user admin ... --admin-address \"0x...\"",
 		EnvVars: []string{"ADMIN_ADDRESS"},
 	}
-	CallerAddress = cli.StringFlag{
+	CallerAddressFlag = cli.StringFlag{
 		Name:    "caller-address",
 		Aliases: []string{"ca"},
 		Usage: "This is the address of the caller who is calling the contract function. \n" +

--- a/pkg/user/admin/remove.go
+++ b/pkg/user/admin/remove.go
@@ -77,11 +77,19 @@ func readAndValidateRemoveAdminConfig(
 ) (*removeAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	adminAddress := gethcommon.HexToAddress(cliContext.String(AdminAddressFlag.Name))
+	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
+	}
+	if common.IsEmptyString(callerAddress.String()) {
+		logger.Infof(
+			"Caller address not provided. Using account address (%s) as caller address",
+			accountAddress,
+		)
+		callerAddress = accountAddress
 	}
 	signerConfig, err := common.GetSignerConfig(cliContext, logger)
 	if err != nil {
@@ -113,6 +121,7 @@ func readAndValidateRemoveAdminConfig(
 		RPCUrl:                   ethRpcUrl,
 		AccountAddress:           accountAddress,
 		AdminAddress:             adminAddress,
+		CallerAddress:            callerAddress,
 		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
 		SignerConfig:             *signerConfig,
 		ChainID:                  chainID,
@@ -129,7 +138,7 @@ func generateRemoveAdminWriter(
 			return nil, eigenSdkUtils.WrapError("failed to create new eth client", err)
 		}
 		return common.GetELWriter(
-			config.AccountAddress,
+			config.CallerAddress,
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
@@ -147,6 +156,7 @@ func removeFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AdminAddressFlag,
+		&CallerAddressFlag,
 		&PermissionControllerAddressFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,

--- a/pkg/user/admin/remove_pending.go
+++ b/pkg/user/admin/remove_pending.go
@@ -79,11 +79,19 @@ func readAndValidateRemovePendingAdminConfig(
 ) (*removePendingAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	adminAddress := gethcommon.HexToAddress(cliContext.String(AdminAddressFlag.Name))
+	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
+	}
+	if common.IsEmptyString(callerAddress.String()) {
+		logger.Infof(
+			"Caller address not provided. Using account address (%s) as caller address",
+			accountAddress,
+		)
+		callerAddress = accountAddress
 	}
 	signerConfig, err := common.GetSignerConfig(cliContext, logger)
 	if err != nil {
@@ -115,6 +123,7 @@ func readAndValidateRemovePendingAdminConfig(
 		RPCUrl:                   ethRpcUrl,
 		AccountAddress:           accountAddress,
 		AdminAddress:             adminAddress,
+		CallerAddress:            callerAddress,
 		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
 		SignerConfig:             *signerConfig,
 		ChainID:                  chainID,
@@ -131,7 +140,7 @@ func generateRemovePendingAdminWriter(
 			return nil, eigenSdkUtils.WrapError("failed to create new eth client", err)
 		}
 		return common.GetELWriter(
-			config.AccountAddress,
+			config.CallerAddress,
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
@@ -149,6 +158,7 @@ func removePendingAdminFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AdminAddressFlag,
+		&CallerAddressFlag,
 		&PermissionControllerAddressFlag,
 		&flags.BroadcastFlag,
 		&flags.OutputTypeFlag,

--- a/pkg/user/admin/types.go
+++ b/pkg/user/admin/types.go
@@ -61,6 +61,7 @@ type addPendingAdminConfig struct {
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
 	AdminAddress             gethcommon.Address
+	CallerAddress            gethcommon.Address
 	PermissionManagerAddress gethcommon.Address
 	SignerConfig             types.SignerConfig
 	ChainID                  *big.Int
@@ -72,6 +73,7 @@ type removeAdminConfig struct {
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
 	AdminAddress             gethcommon.Address
+	CallerAddress            gethcommon.Address
 	PermissionManagerAddress gethcommon.Address
 	SignerConfig             types.SignerConfig
 	ChainID                  *big.Int
@@ -83,6 +85,7 @@ type removePendingAdminConfig struct {
 	RPCUrl                   string
 	AccountAddress           gethcommon.Address
 	AdminAddress             gethcommon.Address
+	CallerAddress            gethcommon.Address
 	PermissionManagerAddress gethcommon.Address
 	SignerConfig             types.SignerConfig
 	ChainID                  *big.Int

--- a/pkg/user/appointee/remove.go
+++ b/pkg/user/appointee/remove.go
@@ -242,6 +242,7 @@ func removeCommandFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AppointeeAddressFlag,
+		&CallerAddressFlag,
 		&TargetAddressFlag,
 		&SelectorFlag,
 		&PermissionControllerAddressFlag,


### PR DESCRIPTION
Adding caller-address to user admin commands to specify arbitrary caller with appointed permissions
Fixes # .

### What Changed?
 - Adding caller-address parameter for write commands.
