### PR TITLE
fix: flakey test

### DIFF
--- a/pkg/operator/allocations/update_test.go
+++ b/pkg/operator/allocations/update_test.go
@@ -219,7 +219,8 @@ func TestGenerateAllocationsParams(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expectedAllocations, allocations)
+				assert.ElementsMatch(t, tt.expectedAllocations.Allocations, allocations.Allocations)
+				assert.Equal(t, tt.expectedAllocations.AllocatableMagnitudes, allocations.AllocatableMagnitudes)
 			}
 		})
 	}


### PR DESCRIPTION
Changes the test assert so that it matches elements of array instead of the array as elements can be in different positions.