### PR TITLE
fix: add caller address to opset reg/dereg

### DIFF
--- a/pkg/operator/deregister_operator_sets.go
+++ b/pkg/operator/deregister_operator_sets.go
@@ -92,7 +92,7 @@ func deregisterAction(cCtx *cli.Context, p utils.Prompter) error {
 		}
 		common.PrintTransactionInfo(receipt.TxHash.String(), config.chainID)
 	} else {
-		noSendTxOpts := common.GetNoSendTxOpts(config.operatorAddress)
+		noSendTxOpts := common.GetNoSendTxOpts(config.callerAddress)
 		_, _, contractBindings, err := elcontracts.BuildClients(elcontracts.Config{
 			DelegationManagerAddress: config.delegationManagerAddress,
 		}, ethClient, nil, logger, nil)
@@ -103,7 +103,7 @@ func deregisterAction(cCtx *cli.Context, p utils.Prompter) error {
 		// since balance of contract can be 0, as it can be called by an EOA
 		// to claim. So we hardcode the gas limit to 150_000 so that we can
 		// create unsigned tx without gas limit estimation from contract bindings
-		if common.IsSmartContractAddress(config.operatorAddress, ethClient) {
+		if common.IsSmartContractAddress(config.callerAddress, ethClient) {
 			// address is a smart contract
 			noSendTxOpts.GasLimit = 150_000
 		}
@@ -169,7 +169,12 @@ func readAndValidateDeregisterConfig(cCtx *cli.Context, logger logging.Logger) (
 	broadcast := cCtx.Bool(flags.BroadcastFlag.Name)
 	isSilent := cCtx.Bool(flags.SilentFlag.Name)
 
-	operatorAddress := gethcommon.HexToAddress(cCtx.String(flags.OperatorAddressFlag.Name))
+	operatorAddress := cCtx.String(flags.OperatorAddressFlag.Name)
+	callerAddress := cCtx.String(flags.CallerAddressFlag.Name)
+	if common.IsEmptyString(callerAddress) {
+		logger.Infof("Caller address not provided. Using operator address (%s) as caller address", operatorAddress)
+		callerAddress = operatorAddress
+	}
 	avsAddress := gethcommon.HexToAddress(cCtx.String(flags.AVSAddressFlag.Name))
 
 	// Get signerConfig
@@ -199,7 +204,8 @@ func readAndValidateDeregisterConfig(cCtx *cli.Context, logger logging.Logger) (
 	config := &DeregisterConfig{
 		avsAddress:               avsAddress,
 		operatorSetIds:           operatorSetIds,
-		operatorAddress:          operatorAddress,
+		operatorAddress:          gethcommon.HexToAddress(operatorAddress),
+		callerAddress:            gethcommon.HexToAddress(callerAddress),
 		network:                  network,
 		environment:              environment,
 		broadcast:                broadcast,
@@ -229,6 +235,7 @@ func getDeregistrationFlags() []cli.Flag {
 		&flags.OperatorSetIdsFlag,
 		&flags.DelegationManagerAddressFlag,
 		&flags.SilentFlag,
+		&flags.CallerAddressFlag,
 	}
 
 	allFlags := append(baseFlags, flags.GetSignerFlags()...)

--- a/pkg/operator/deregister_operator_sets.go
+++ b/pkg/operator/deregister_operator_sets.go
@@ -66,7 +66,7 @@ func deregisterAction(cCtx *cli.Context, p utils.Prompter) error {
 		}
 		logger.Info("Signing and broadcasting deregistration transaction")
 		eLWriter, err := common.GetELWriter(
-			config.operatorAddress,
+			config.callerAddress,
 			config.signerConfig,
 			ethClient,
 			elcontracts.Config{

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -62,7 +62,7 @@ func registerOperatorSetsAction(cCtx *cli.Context, p utils.Prompter) error {
 		}
 		logger.Info("Signing and broadcasting registration transaction")
 		eLWriter, err := common.GetELWriter(
-			config.operatorAddress,
+			config.callerAddress,
 			config.signerConfig,
 			ethClient,
 			elcontracts.Config{

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -87,7 +87,7 @@ func registerOperatorSetsAction(cCtx *cli.Context, p utils.Prompter) error {
 		}
 		common.PrintTransactionInfo(receipt.TxHash.String(), config.chainID)
 	} else {
-		noSendTxOpts := common.GetNoSendTxOpts(config.operatorAddress)
+		noSendTxOpts := common.GetNoSendTxOpts(config.callerAddress)
 		_, _, contractBindings, err := elcontracts.BuildClients(elcontracts.Config{
 			DelegationManagerAddress: config.delegationManagerAddress,
 		}, ethClient, nil, logger, nil)
@@ -98,7 +98,7 @@ func registerOperatorSetsAction(cCtx *cli.Context, p utils.Prompter) error {
 		// since balance of contract can be 0, as it can be called by an EOA
 		// to claim. So we hardcode the gas limit to 150_000 so that we can
 		// create unsigned tx without gas limit estimation from contract bindings
-		if common.IsSmartContractAddress(config.operatorAddress, ethClient) {
+		if common.IsSmartContractAddress(config.callerAddress, ethClient) {
 			// address is a smart contract
 			noSendTxOpts.GasLimit = 150_000
 		}
@@ -155,7 +155,12 @@ func readAndValidateRegisterOperatorSetsConfig(cCtx *cli.Context, logger logging
 	broadcast := cCtx.Bool(flags.BroadcastFlag.Name)
 	isSilent := cCtx.Bool(flags.SilentFlag.Name)
 
-	operatorAddress := gethcommon.HexToAddress(cCtx.String(flags.OperatorAddressFlag.Name))
+	operatorAddress := cCtx.String(flags.OperatorAddressFlag.Name)
+	callerAddress := cCtx.String(flags.CallerAddressFlag.Name)
+	if common.IsEmptyString(callerAddress) {
+		logger.Infof("Caller address not provided. Using operator address (%s) as caller address", operatorAddress)
+		callerAddress = operatorAddress
+	}
 	avsAddress := gethcommon.HexToAddress(cCtx.String(flags.AVSAddressFlag.Name))
 
 	// Get signerConfig
@@ -185,7 +190,8 @@ func readAndValidateRegisterOperatorSetsConfig(cCtx *cli.Context, logger logging
 	config := &RegisterConfig{
 		avsAddress:               avsAddress,
 		operatorSetIds:           operatorSetIds,
-		operatorAddress:          operatorAddress,
+		operatorAddress:          gethcommon.HexToAddress(operatorAddress),
+		callerAddress:            gethcommon.HexToAddress(callerAddress),
 		network:                  network,
 		environment:              environment,
 		broadcast:                broadcast,
@@ -215,6 +221,7 @@ func getRegistrationFlags() []cli.Flag {
 		&flags.OperatorSetIdsFlag,
 		&flags.DelegationManagerAddressFlag,
 		&flags.SilentFlag,
+		&flags.CallerAddressFlag,
 	}
 
 	allFlags := append(baseFlags, flags.GetSignerFlags()...)

--- a/pkg/operator/types.go
+++ b/pkg/operator/types.go
@@ -11,6 +11,7 @@ type DeregisterConfig struct {
 	avsAddress               common.Address
 	operatorSetIds           []uint32
 	operatorAddress          common.Address
+	callerAddress            common.Address
 	network                  string
 	environment              string
 	broadcast                bool
@@ -27,6 +28,7 @@ type RegisterConfig struct {
 	avsAddress               common.Address
 	operatorSetIds           []uint32
 	operatorAddress          common.Address
+	callerAddress            common.Address
 	network                  string
 	environment              string
 	broadcast                bool


### PR DESCRIPTION
Fixes # .

### What Changed?
- Add `caller-address` for operator set registration and deregistration
