### PR TITLE
Adding output support to file or terminal without broadcast for user admin commands.

### DIFF
--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -13,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"

--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -2,6 +2,8 @@ package admin
 
 import (
 	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -23,6 +25,10 @@ type AcceptAdminWriter interface {
 		ctx context.Context,
 		request elcontracts.AcceptAdminRequest,
 	) (*gethtypes.Receipt, error)
+	NewAcceptAdminTx(
+		txOpts *bind.TransactOpts,
+		request elcontracts.AcceptAdminRequest,
+	) (*gethtypes.Transaction, error)
 }
 
 func AcceptCmd(generator func(logging.Logger, *acceptAdminConfig) (AcceptAdminWriter, error)) *cli.Command {
@@ -56,14 +62,80 @@ func acceptAdmin(
 		return err
 	}
 
-	receipt, err := elWriter.AcceptAdmin(
-		ctx,
-		elcontracts.AcceptAdminRequest{AccountAddress: config.AccountAddress, WaitForReceipt: true},
-	)
+	acceptRequest := elcontracts.AcceptAdminRequest{
+		AccountAddress: config.AccountAddress,
+		WaitForReceipt: true,
+	}
+
+	if config.Broadcast {
+		return broadcastAcceptAdminTx(ctx, elWriter, config, acceptRequest)
+	}
+
+	return printAcceptAdminTx(logger, elWriter, config, acceptRequest)
+}
+
+func broadcastAcceptAdminTx(
+	ctx context.Context,
+	elWriter AcceptAdminWriter,
+	config *acceptAdminConfig,
+	request elcontracts.AcceptAdminRequest,
+) error {
+	receipt, err := elWriter.AcceptAdmin(ctx, request)
+	if err != nil {
+		return eigenSdkUtils.WrapError("failed to broadcast AcceptAdmin transaction", err)
+	}
+	common.PrintTransactionInfo(receipt.TxHash.String(), config.ChainID)
+	return nil
+}
+
+func printAcceptAdminTx(
+	logger logging.Logger,
+	elWriter AcceptAdminWriter,
+	config *acceptAdminConfig,
+	request elcontracts.AcceptAdminRequest,
+) error {
+	ethClient, err := ethclient.Dial(config.RPCUrl)
 	if err != nil {
 		return err
 	}
-	common.PrintTransactionInfo(receipt.TxHash.String(), config.ChainID)
+
+	noSendTxOpts := common.GetNoSendTxOpts(config.CallerAddress)
+	if common.IsSmartContractAddress(config.CallerAddress, ethClient) {
+		noSendTxOpts.GasLimit = 150_000
+	}
+
+	// Generate unsigned transaction
+	unsignedTx, err := elWriter.NewAcceptAdminTx(noSendTxOpts, request)
+	if err != nil {
+		return eigenSdkUtils.WrapError("failed to create unsigned tx", err)
+	}
+
+	if config.OutputType == string(common.OutputType_Calldata) {
+		calldataHex := gethcommon.Bytes2Hex(unsignedTx.Data())
+		if !common.IsEmptyString(config.OutputFile) {
+			err = common.WriteToFile([]byte(calldataHex), config.OutputFile)
+			if err != nil {
+				return err
+			}
+			logger.Infof("Call data written to file: %s", config.OutputFile)
+		} else {
+			fmt.Println(calldataHex)
+		}
+	} else {
+		if !common.IsEmptyString(config.OutputType) {
+			fmt.Println("output file not supported for pretty output type")
+			fmt.Println()
+		}
+		fmt.Printf(
+			"Pending admin at address %s will accept admin role\n",
+			config.CallerAddress,
+		)
+	}
+
+	txFeeDetails := common.GetTxFeeDetails(unsignedTx)
+	fmt.Println()
+	txFeeDetails.Print()
+	fmt.Println("To broadcast the transaction, use the --broadcast flag")
 	return nil
 }
 
@@ -76,6 +148,9 @@ func readAndValidateAcceptAdminConfig(
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
+	outputType := cliContext.String(flags.OutputTypeFlag.Name)
+	outputFile := cliContext.String(flags.OutputFileFlag.Name)
+	broadcast := cliContext.Bool(flags.BroadcastFlag.Name)
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
 	}
@@ -120,6 +195,9 @@ func readAndValidateAcceptAdminConfig(
 		SignerConfig:             *signerConfig,
 		ChainID:                  chainID,
 		Environment:              environment,
+		OutputFile:               outputFile,
+		OutputType:               outputType,
+		Broadcast:                broadcast,
 	}, nil
 }
 

--- a/pkg/user/admin/accept_test.go
+++ b/pkg/user/admin/accept_test.go
@@ -3,11 +3,11 @@ package admin
 import (
 	"context"
 	"errors"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"testing"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"

--- a/pkg/user/admin/add_pending.go
+++ b/pkg/user/admin/add_pending.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -11,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -23,6 +25,10 @@ type AddPendingAdminWriter interface {
 		ctx context.Context,
 		request elcontracts.AddPendingAdminRequest,
 	) (*gethtypes.Receipt, error)
+	NewAddPendingAdminTx(
+		txOpts *bind.TransactOpts,
+		request elcontracts.AddPendingAdminRequest,
+	) (*gethtypes.Transaction, error)
 }
 
 func AddPendingCmd(generator func(logging.Logger, *addPendingAdminConfig) (AddPendingAdminWriter, error)) *cli.Command {
@@ -56,13 +62,77 @@ func addPendingAdmin(
 		return err
 	}
 
+	addPendingRequest := elcontracts.AddPendingAdminRequest{
+		AccountAddress: config.AccountAddress,
+		AdminAddress:   config.AdminAddress,
+		WaitForReceipt: true,
+	}
+
+	if config.Broadcast {
+		return broadcastAddPendingAdminTx(ctx, elWriter, config, addPendingRequest)
+	}
+	return printAddPendingAdminTx(logger, elWriter, config, addPendingRequest)
+}
+
+func printAddPendingAdminTx(
+	logger logging.Logger,
+	elWriter AddPendingAdminWriter,
+	config *addPendingAdminConfig,
+	request elcontracts.AddPendingAdminRequest,
+) error {
+	ethClient, err := ethclient.Dial(config.RPCUrl)
+	if err != nil {
+		return err
+	}
+	noSendTxOpts := common.GetNoSendTxOpts(config.CallerAddress)
+	if common.IsSmartContractAddress(config.CallerAddress, ethClient) {
+		// address is a smart contract
+		noSendTxOpts.GasLimit = 150_000
+	}
+
+	unsignedTx, err := elWriter.NewAddPendingAdminTx(noSendTxOpts, request)
+	if err != nil {
+		return eigenSdkUtils.WrapError("failed to create unsigned tx", err)
+	}
+
+	if config.OutputType == string(common.OutputType_Calldata) {
+		calldataHex := gethcommon.Bytes2Hex(unsignedTx.Data())
+		if !common.IsEmptyString(config.OutputFile) {
+			err = common.WriteToFile([]byte(calldataHex), config.OutputFile)
+			if err != nil {
+				return err
+			}
+			logger.Infof("Call data written to file: %s", config.OutputFile)
+		} else {
+			fmt.Println(calldataHex)
+		}
+	} else {
+		if !common.IsEmptyString(config.OutputType) {
+			fmt.Println("output file not supported for pretty output type")
+			fmt.Println()
+		}
+		fmt.Printf(
+			"Admin %s will be added as pending for account %s\n",
+			config.AdminAddress,
+			config.AccountAddress,
+		)
+	}
+	txFeeDetails := common.GetTxFeeDetails(unsignedTx)
+	fmt.Println()
+	txFeeDetails.Print()
+	fmt.Println("To broadcast the transaction, use the --broadcast flag")
+	return nil
+}
+
+func broadcastAddPendingAdminTx(
+	ctx context.Context,
+	elWriter AddPendingAdminWriter,
+	config *addPendingAdminConfig,
+	request elcontracts.AddPendingAdminRequest,
+) error {
 	receipt, err := elWriter.AddPendingAdmin(
 		ctx,
-		elcontracts.AddPendingAdminRequest{
-			AccountAddress: config.AccountAddress,
-			AdminAddress:   config.AdminAddress,
-			WaitForReceipt: true,
-		},
+		request,
 	)
 	if err != nil {
 		return err
@@ -81,6 +151,9 @@ func readAndValidateAddPendingAdminConfig(
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
+	outputType := cliContext.String(flags.OutputTypeFlag.Name)
+	outputFile := cliContext.String(flags.OutputFileFlag.Name)
+	broadcast := cliContext.Bool(flags.BroadcastFlag.Name)
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
 	}
@@ -126,6 +199,9 @@ func readAndValidateAddPendingAdminConfig(
 		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
 		ChainID:                  chainID,
 		Environment:              environment,
+		OutputFile:               outputFile,
+		OutputType:               outputType,
+		Broadcast:                broadcast,
 	}, nil
 }
 

--- a/pkg/user/admin/remove.go
+++ b/pkg/user/admin/remove.go
@@ -2,6 +2,8 @@ package admin
 
 import (
 	"context"
+	"fmt"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -23,6 +25,10 @@ type RemoveAdminWriter interface {
 		ctx context.Context,
 		request elcontracts.RemoveAdminRequest,
 	) (*gethtypes.Receipt, error)
+	NewRemoveAdminTx(
+		txOpts *bind.TransactOpts,
+		request elcontracts.RemoveAdminRequest,
+	) (*gethtypes.Transaction, error)
 }
 
 func RemoveCmd(generator func(logging.Logger, *removeAdminConfig) (RemoveAdminWriter, error)) *cli.Command {
@@ -56,18 +62,80 @@ func removeAdmin(
 		return err
 	}
 
-	receipt, err := elWriter.RemoveAdmin(
-		ctx,
-		elcontracts.RemoveAdminRequest{
-			AccountAddress: config.AccountAddress,
-			AdminAddress:   config.AdminAddress,
-			WaitForReceipt: true,
-		},
-	)
+	removeRequest := elcontracts.RemoveAdminRequest{
+		AccountAddress: config.AccountAddress,
+		AdminAddress:   config.AdminAddress,
+		WaitForReceipt: true,
+	}
+
+	if config.Broadcast {
+		return broadcastRemoveAdminTx(ctx, elWriter, config, removeRequest)
+	}
+
+	return printRemoveAdminTx(logger, elWriter, config, removeRequest)
+}
+
+func broadcastRemoveAdminTx(
+	ctx context.Context,
+	elWriter RemoveAdminWriter,
+	config *removeAdminConfig,
+	request elcontracts.RemoveAdminRequest,
+) error {
+	receipt, err := elWriter.RemoveAdmin(ctx, request)
+	if err != nil {
+		return eigenSdkUtils.WrapError("failed to broadcast RemoveAdmin transaction", err)
+	}
+	common.PrintTransactionInfo(receipt.TxHash.String(), config.ChainID)
+	return nil
+}
+
+func printRemoveAdminTx(
+	logger logging.Logger,
+	elWriter RemoveAdminWriter,
+	config *removeAdminConfig,
+	request elcontracts.RemoveAdminRequest,
+) error {
+	ethClient, err := ethclient.Dial(config.RPCUrl)
 	if err != nil {
 		return err
 	}
-	common.PrintTransactionInfo(receipt.TxHash.String(), config.ChainID)
+
+	noSendTxOpts := common.GetNoSendTxOpts(config.CallerAddress)
+	if common.IsSmartContractAddress(config.CallerAddress, ethClient) {
+		noSendTxOpts.GasLimit = 150_000
+	}
+	unsignedTx, err := elWriter.NewRemoveAdminTx(noSendTxOpts, request)
+	if err != nil {
+		return eigenSdkUtils.WrapError("failed to create unsigned tx", err)
+	}
+
+	if config.OutputType == string(common.OutputType_Calldata) {
+		calldataHex := gethcommon.Bytes2Hex(unsignedTx.Data())
+		if !common.IsEmptyString(config.OutputFile) {
+			err = common.WriteToFile([]byte(calldataHex), config.OutputFile)
+			if err != nil {
+				return err
+			}
+			logger.Infof("Call data written to file: %s", config.OutputFile)
+		} else {
+			fmt.Println(calldataHex)
+		}
+	} else {
+		if !common.IsEmptyString(config.OutputType) {
+			fmt.Println("output file not supported for pretty output type")
+			fmt.Println()
+		}
+		fmt.Printf(
+			"Admin %s will be removed for account %s\n",
+			config.AdminAddress,
+			config.AccountAddress,
+		)
+	}
+
+	txFeeDetails := common.GetTxFeeDetails(unsignedTx)
+	fmt.Println()
+	txFeeDetails.Print()
+	fmt.Println("To broadcast the transaction, use the --broadcast flag")
 	return nil
 }
 
@@ -81,6 +149,9 @@ func readAndValidateRemoveAdminConfig(
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
+	outputType := cliContext.String(flags.OutputTypeFlag.Name)
+	outputFile := cliContext.String(flags.OutputFileFlag.Name)
+	broadcast := cliContext.Bool(flags.BroadcastFlag.Name)
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
 	}
@@ -126,6 +197,9 @@ func readAndValidateRemoveAdminConfig(
 		SignerConfig:             *signerConfig,
 		ChainID:                  chainID,
 		Environment:              environment,
+		OutputFile:               outputFile,
+		OutputType:               outputType,
+		Broadcast:                broadcast,
 	}, nil
 }
 

--- a/pkg/user/admin/remove.go
+++ b/pkg/user/admin/remove.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -13,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"

--- a/pkg/user/admin/remove_pending.go
+++ b/pkg/user/admin/remove_pending.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -13,6 +12,7 @@ import (
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"

--- a/pkg/user/admin/types.go
+++ b/pkg/user/admin/types.go
@@ -54,6 +54,9 @@ type acceptAdminConfig struct {
 	SignerConfig             types.SignerConfig
 	ChainID                  *big.Int
 	Environment              string
+	OutputFile               string
+	OutputType               string
+	Broadcast                bool
 }
 
 type addPendingAdminConfig struct {
@@ -66,6 +69,9 @@ type addPendingAdminConfig struct {
 	SignerConfig             types.SignerConfig
 	ChainID                  *big.Int
 	Environment              string
+	OutputFile               string
+	OutputType               string
+	Broadcast                bool
 }
 
 type removeAdminConfig struct {
@@ -78,6 +84,9 @@ type removeAdminConfig struct {
 	SignerConfig             types.SignerConfig
 	ChainID                  *big.Int
 	Environment              string
+	OutputFile               string
+	OutputType               string
+	Broadcast                bool
 }
 
 type removePendingAdminConfig struct {
@@ -90,4 +99,7 @@ type removePendingAdminConfig struct {
 	SignerConfig             types.SignerConfig
 	ChainID                  *big.Int
 	Environment              string
+	OutputFile               string
+	OutputType               string
+	Broadcast                bool
 }


### PR DESCRIPTION
Adding output support to file or terminal without broadcast for user admin commands.

### What Changed?
 - Output support for user admin write commands
 - Broadcast conditional support for user admin write commands
 - Unit test updates
