### PR TITLE
fix: showing allocations for registered ops

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.12 h1:G5Q1SnLmFbEjhOkky3vIHk
 github.com/Layr-Labs/eigenlayer-rewards-proofs v0.2.12/go.mod h1:OlJd1QjqEW53wfWG/lJyPCGvrXwWVEjPQsP4TV+gttQ=
 github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-5c11a259293e h1:DvW0/kWHV9mZsbH2KOjEHKTSIONNPUj6X05FJvUohy4=
 github.com/Layr-Labs/eigenpod-proofs-generation v0.0.14-stable.0.20240730152248-5c11a259293e/go.mod h1:T7tYN8bTdca2pkMnz9G2+ZwXYWw5gWqQUIu4KLgC/vM=
-github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241217222530-549e0185cee6 h1:v2SQn+Yq/HMAkv0a11NHnZXJS0K+2F4JWU0ogOV6+jg=
-github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241217222530-549e0185cee6/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241217234459-1dd4a5c5b30a h1:spyS+Tp1PgVIPmAesVVRuOkC3jAZRyKXhttAieTBxmg=
 github.com/Layr-Labs/eigensdk-go v0.1.14-0.20241217234459-1dd4a5c5b30a/go.mod h1:aYdNURUhaqeYOS+Cq12TfSdPbjFfiLaHkxPdR4Exq/s=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -78,12 +78,13 @@ func registerOperatorSetsAction(cCtx *cli.Context, p utils.Prompter) error {
 		receipt, err := eLWriter.RegisterForOperatorSets(
 			ctx,
 			elcontracts.RegistrationRequest{
-				AVSAddress:     config.avsAddress,
-				OperatorSetIds: config.operatorSetIds,
-				WaitForReceipt: true,
+				OperatorAddress: config.operatorAddress,
+				AVSAddress:      config.avsAddress,
+				OperatorSetIds:  config.operatorSetIds,
+				WaitForReceipt:  true,
 			})
 		if err != nil {
-			return eigenSdkUtils.WrapError("failed to deregister from operator sets", err)
+			return eigenSdkUtils.WrapError("failed to register for operator sets", err)
 		}
 		common.PrintTransactionInfo(receipt.TxHash.String(), config.chainID)
 	} else {


### PR DESCRIPTION
Fixes # .

### What Changed?
- Fix a case where operator is deregistered and the contract API doesn't return the slashable shares as the operator is deregistered. But protocol still has magnitude allocated (which is no unused) for that case. So in order to show that we make a map of deregistered and show that. We change the order of execution so if don't execute rest of operations if opset is deregistered 
- There's a comment there on how to change order of iteration which will make more sense. We will do it in subsequent PR.
- Fix a bug where we forgot to pass operator address to eigensdk. 
