### PR TITLE
Updating output code path to correctly detect empty string input for caller-address

### DIFF
--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -144,7 +145,7 @@ func readAndValidateAcceptAdminConfig(
 	logger logging.Logger,
 ) (*acceptAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
-	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
+	callerAddress := user.PopulateCallerAddress(cliContext, logger, accountAddress)
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -170,14 +171,6 @@ func readAndValidateAcceptAdminConfig(
 			return nil, err
 		}
 	}
-	if common.IsEmptyString(callerAddress.String()) {
-		logger.Infof(
-			"Caller address not provided. Using account address (%s) as caller address",
-			accountAddress,
-		)
-		callerAddress = accountAddress
-	}
-
 	logger.Debugf(
 		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
 		environment,
@@ -205,7 +198,7 @@ func acceptFlags() []cli.Flag {
 	cmdFlags := []cli.Flag{
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
-		&CallerAddressFlag,
+		&user.CallerAddressFlag,
 		&PermissionControllerAddressFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,

--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -3,12 +3,12 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"

--- a/pkg/user/admin/add_pending.go
+++ b/pkg/user/admin/add_pending.go
@@ -3,12 +3,12 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"

--- a/pkg/user/admin/add_pending.go
+++ b/pkg/user/admin/add_pending.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -147,7 +148,7 @@ func readAndValidateAddPendingAdminConfig(
 ) (*addPendingAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	adminAddress := gethcommon.HexToAddress(cliContext.String(AdminAddressFlag.Name))
-	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
+	callerAddress := user.PopulateCallerAddress(cliContext, logger, accountAddress)
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -156,13 +157,6 @@ func readAndValidateAddPendingAdminConfig(
 	broadcast := cliContext.Bool(flags.BroadcastFlag.Name)
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
-	}
-	if common.IsEmptyString(callerAddress.String()) {
-		logger.Infof(
-			"Caller address not provided. Using account address (%s) as caller address",
-			accountAddress,
-		)
-		callerAddress = accountAddress
 	}
 	signerConfig, err := common.GetSignerConfig(cliContext, logger)
 	if err != nil {
@@ -232,7 +226,7 @@ func addPendingFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AdminAddressFlag,
-		&CallerAddressFlag,
+		&user.CallerAddressFlag,
 		&PermissionControllerAddressFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,

--- a/pkg/user/admin/flags.go
+++ b/pkg/user/admin/flags.go
@@ -15,13 +15,6 @@ var (
 		Usage:   "user admin ... --admin-address \"0x...\"",
 		EnvVars: []string{"ADMIN_ADDRESS"},
 	}
-	CallerAddressFlag = cli.StringFlag{
-		Name:    "caller-address",
-		Aliases: []string{"ca"},
-		Usage: "This is the address of the caller who is calling the contract function. \n" +
-			"If it is not provided, the account address will be used as the caller address",
-		EnvVars: []string{"CALLER_ADDRESS"},
-	}
 	PendingAdminAddressFlag = cli.StringFlag{
 		Name:    "pending-admin-address",
 		Aliases: []string{"paa"},

--- a/pkg/user/admin/remove.go
+++ b/pkg/user/admin/remove.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -145,7 +146,7 @@ func readAndValidateRemoveAdminConfig(
 ) (*removeAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	adminAddress := gethcommon.HexToAddress(cliContext.String(AdminAddressFlag.Name))
-	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
+	callerAddress := user.PopulateCallerAddress(cliContext, logger, accountAddress)
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -154,13 +155,6 @@ func readAndValidateRemoveAdminConfig(
 	broadcast := cliContext.Bool(flags.BroadcastFlag.Name)
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
-	}
-	if common.IsEmptyString(callerAddress.String()) {
-		logger.Infof(
-			"Caller address not provided. Using account address (%s) as caller address",
-			accountAddress,
-		)
-		callerAddress = accountAddress
 	}
 	signerConfig, err := common.GetSignerConfig(cliContext, logger)
 	if err != nil {
@@ -230,7 +224,7 @@ func removeFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AdminAddressFlag,
-		&CallerAddressFlag,
+		&user.CallerAddressFlag,
 		&PermissionControllerAddressFlag,
 		&flags.OutputTypeFlag,
 		&flags.OutputFileFlag,

--- a/pkg/user/admin/remove.go
+++ b/pkg/user/admin/remove.go
@@ -3,12 +3,12 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"

--- a/pkg/user/admin/remove_pending.go
+++ b/pkg/user/admin/remove_pending.go
@@ -3,12 +3,12 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"

--- a/pkg/user/admin/remove_pending.go
+++ b/pkg/user/admin/remove_pending.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -145,7 +146,7 @@ func readAndValidateRemovePendingAdminConfig(
 ) (*removePendingAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	adminAddress := gethcommon.HexToAddress(cliContext.String(AdminAddressFlag.Name))
-	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
+	callerAddress := user.PopulateCallerAddress(cliContext, logger, accountAddress)
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -154,13 +155,6 @@ func readAndValidateRemovePendingAdminConfig(
 	broadcast := cliContext.Bool(flags.BroadcastFlag.Name)
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
-	}
-	if common.IsEmptyString(callerAddress.String()) {
-		logger.Infof(
-			"Caller address not provided. Using account address (%s) as caller address",
-			accountAddress,
-		)
-		callerAddress = accountAddress
 	}
 	signerConfig, err := common.GetSignerConfig(cliContext, logger)
 	if err != nil {
@@ -230,7 +224,7 @@ func removePendingAdminFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AdminAddressFlag,
-		&CallerAddressFlag,
+		&user.CallerAddressFlag,
 		&PermissionControllerAddressFlag,
 		&flags.BroadcastFlag,
 		&flags.OutputTypeFlag,

--- a/pkg/user/appointee/flags.go
+++ b/pkg/user/appointee/flags.go
@@ -15,13 +15,6 @@ var (
 		Usage:   "The Ethereum address of the user. Example: --appointee-address \"0x...\"",
 		EnvVars: []string{"APPOINTEE_ADDRESS"},
 	}
-	CallerAddressFlag = cli.StringFlag{
-		Name:    "caller-address",
-		Aliases: []string{"ca"},
-		Usage: "This is the address of the caller who is calling the contract function. \n" +
-			"If it is not provided, the account address will be used as the caller address",
-		EnvVars: []string{"CALLER_ADDRESS"},
-	}
 	SelectorFlag = cli.StringFlag{
 		Name:    "selector",
 		Aliases: []string{"s"},

--- a/pkg/user/appointee/remove.go
+++ b/pkg/user/appointee/remove.go
@@ -3,6 +3,7 @@ package appointee
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -170,7 +171,7 @@ func generateRemoveAppointeePermissionWriter(
 func readAndValidateRemoveConfig(cliContext *cli.Context, logger logging.Logger) (*removeConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	appointeeAddress := gethcommon.HexToAddress(cliContext.String(AppointeeAddressFlag.Name))
-	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
+	callerAddress := user.PopulateCallerAddress(cliContext, logger, accountAddress)
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -204,14 +205,6 @@ func readAndValidateRemoveConfig(cliContext *cli.Context, logger logging.Logger)
 			return nil, err
 		}
 	}
-	if common.IsEmptyString(callerAddress.String()) {
-		logger.Infof(
-			"Caller address not provided. Using account address (%s) as caller address",
-			accountAddress,
-		)
-		callerAddress = accountAddress
-	}
-
 	logger.Debugf(
 		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
 		environment,
@@ -243,7 +236,7 @@ func removeCommandFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AppointeeAddressFlag,
-		&CallerAddressFlag,
+		&user.CallerAddressFlag,
 		&TargetAddressFlag,
 		&SelectorFlag,
 		&PermissionControllerAddressFlag,

--- a/pkg/user/appointee/remove.go
+++ b/pkg/user/appointee/remove.go
@@ -3,12 +3,12 @@ package appointee
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"

--- a/pkg/user/appointee/set.go
+++ b/pkg/user/appointee/set.go
@@ -3,6 +3,7 @@ package appointee
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -173,7 +174,7 @@ func generateSetAppointeePermissionWriter(
 func readAndValidateSetConfig(cliContext *cli.Context, logger logging.Logger) (*setConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
 	appointeeAddress := gethcommon.HexToAddress(cliContext.String(AppointeeAddressFlag.Name))
-	callerAddress := gethcommon.HexToAddress(cliContext.String(CallerAddressFlag.Name))
+	callerAddress := user.PopulateCallerAddress(cliContext, logger, accountAddress)
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)
@@ -195,13 +196,6 @@ func readAndValidateSetConfig(cliContext *cli.Context, logger logging.Logger) (*
 
 	if environment == "" {
 		environment = common.GetEnvFromNetwork(network)
-	}
-	if common.IsEmptyString(callerAddress.String()) {
-		logger.Infof(
-			"Caller address not provided. Using account address (%s) as caller address",
-			accountAddress,
-		)
-		callerAddress = accountAddress
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
@@ -246,7 +240,7 @@ func setCommandFlags() []cli.Flag {
 		&flags.VerboseFlag,
 		&AccountAddressFlag,
 		&AppointeeAddressFlag,
-		&CallerAddressFlag,
+		&user.CallerAddressFlag,
 		&TargetAddressFlag,
 		&SelectorFlag,
 		&PermissionControllerAddressFlag,

--- a/pkg/user/appointee/set.go
+++ b/pkg/user/appointee/set.go
@@ -3,12 +3,12 @@ package appointee
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"

--- a/pkg/user/flags.go
+++ b/pkg/user/flags.go
@@ -1,0 +1,13 @@
+package user
+
+import "github.com/urfave/cli/v2"
+
+var (
+	CallerAddressFlag = cli.StringFlag{
+		Name:    "caller-address",
+		Aliases: []string{"ca"},
+		Usage: "This is the address of the caller who is calling the contract function. \n" +
+			"If it is not provided, the account address will be used as the caller address",
+		EnvVars: []string{"CALLER_ADDRESS"},
+	}
+)

--- a/pkg/user/helper.go
+++ b/pkg/user/helper.go
@@ -1,0 +1,26 @@
+package user
+
+import (
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
+	"github.com/Layr-Labs/eigensdk-go/logging"
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/urfave/cli/v2"
+)
+
+func PopulateCallerAddress(
+	cliContext *cli.Context,
+	logger logging.Logger,
+	accountAddress gethcommon.Address,
+) gethcommon.Address {
+	// TODO: these are copied across both callers of this method. Will clean this up in the CLI refactor of flags.
+	callerAddress := cliContext.String(CallerAddressFlag.Name)
+	if common.IsEmptyString(callerAddress) {
+		logger.Infof(
+			"Caller address not provided. Using account address (%s) as caller address",
+			accountAddress,
+		)
+
+		return accountAddress
+	}
+	return gethcommon.HexToAddress(callerAddress)
+}


### PR DESCRIPTION
Updating output code path to correctly detect empty string input for caller-address. Because the input was wrapped in an address object, it defaulted to the 0x0.. address which doesn't match the empty string check enforced.

When the caller address is not provided we want to default to the `account-address` provided. 

### What Changed?
 - properly detects empty `caller-address` and replaces with`account-address`.
