### PR TITLE
Rename permission manager

### DIFF
--- a/pkg/internal/common/helper.go
+++ b/pkg/internal/common/helper.go
@@ -48,31 +48,31 @@ const (
 
 var ChainMetadataMap = map[int64]types.ChainMetadata{
 	MainnetChainId: {
-		BlockExplorerUrl:            "https://etherscan.io/tx",
-		ELDelegationManagerAddress:  "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A",
-		ELAVSDirectoryAddress:       "0x135dda560e946695d6f155dacafc6f1f25c1f5af",
-		ELRewardsCoordinatorAddress: "0x7750d328b314EfFa365A0402CcfD489B80B0adda",
-		ELPermissionManagerAddress:  "",
-		WebAppUrl:                   "https://app.eigenlayer.xyz/operator",
-		ProofStoreBaseURL:           "https://eigenlabs-rewards-mainnet-ethereum.s3.amazonaws.com",
+		BlockExplorerUrl:              "https://etherscan.io/tx",
+		ELDelegationManagerAddress:    "0x39053D51B77DC0d36036Fc1fCc8Cb819df8Ef37A",
+		ELAVSDirectoryAddress:         "0x135dda560e946695d6f155dacafc6f1f25c1f5af",
+		ELRewardsCoordinatorAddress:   "0x7750d328b314EfFa365A0402CcfD489B80B0adda",
+		ELPermissionControllerAddress: "",
+		WebAppUrl:                     "https://app.eigenlayer.xyz/operator",
+		ProofStoreBaseURL:             "https://eigenlabs-rewards-mainnet-ethereum.s3.amazonaws.com",
 	},
 	HoleskyChainId: {
-		BlockExplorerUrl:            "https://holesky.etherscan.io/tx",
-		ELDelegationManagerAddress:  "0xA44151489861Fe9e3055d95adC98FbD462B948e7",
-		ELAVSDirectoryAddress:       "0x055733000064333CaDDbC92763c58BF0192fFeBf",
-		ELRewardsCoordinatorAddress: "0xAcc1fb458a1317E886dB376Fc8141540537E68fE",
-		ELPermissionManagerAddress:  "0x598cb226B591155F767dA17AfE7A2241a68C5C10",
-		WebAppUrl:                   "https://holesky.eigenlayer.xyz/operator",
-		ProofStoreBaseURL:           "https://eigenlabs-rewards-testnet-holesky.s3.amazonaws.com",
+		BlockExplorerUrl:              "https://holesky.etherscan.io/tx",
+		ELDelegationManagerAddress:    "0xA44151489861Fe9e3055d95adC98FbD462B948e7",
+		ELAVSDirectoryAddress:         "0x055733000064333CaDDbC92763c58BF0192fFeBf",
+		ELRewardsCoordinatorAddress:   "0xAcc1fb458a1317E886dB376Fc8141540537E68fE",
+		ELPermissionControllerAddress: "0x598cb226B591155F767dA17AfE7A2241a68C5C10",
+		WebAppUrl:                     "https://holesky.eigenlayer.xyz/operator",
+		ProofStoreBaseURL:             "https://eigenlabs-rewards-testnet-holesky.s3.amazonaws.com",
 	},
 	AnvilChainId: {
-		BlockExplorerUrl:            "",
-		ELDelegationManagerAddress:  "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
-		ELAVSDirectoryAddress:       "0x0165878A594ca255338adfa4d48449f69242Eb8F",
-		ELRewardsCoordinatorAddress: "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
-		ELPermissionManagerAddress:  "",
-		WebAppUrl:                   "",
-		ProofStoreBaseURL:           "",
+		BlockExplorerUrl:              "",
+		ELDelegationManagerAddress:    "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+		ELAVSDirectoryAddress:         "0x0165878A594ca255338adfa4d48449f69242Eb8F",
+		ELRewardsCoordinatorAddress:   "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
+		ELPermissionControllerAddress: "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
+		WebAppUrl:                     "",
+		ProofStoreBaseURL:             "",
 	},
 }
 
@@ -342,13 +342,13 @@ func GetDelegationManagerAddress(chainID *big.Int) (string, error) {
 	}
 }
 
-func GetPermissionManagerAddress(chainID *big.Int) (string, error) {
+func GetPermissionControllerAddress(chainID *big.Int) (string, error) {
 	chainIDInt := chainID.Int64()
 	chainMetadata, ok := ChainMetadataMap[chainIDInt]
 	if !ok {
 		return "", fmt.Errorf("chain ID %d not supported", chainIDInt)
 	} else {
-		return chainMetadata.ELDelegationManagerAddress, nil
+		return chainMetadata.ELPermissionControllerAddress, nil
 	}
 }
 

--- a/pkg/types/chain_metadata.go
+++ b/pkg/types/chain_metadata.go
@@ -1,11 +1,11 @@
 package types
 
 type ChainMetadata struct {
-	BlockExplorerUrl            string
-	ELDelegationManagerAddress  string
-	ELAVSDirectoryAddress       string
-	ELRewardsCoordinatorAddress string
-	ELPermissionManagerAddress  string
-	WebAppUrl                   string
-	ProofStoreBaseURL           string
+	BlockExplorerUrl              string
+	ELDelegationManagerAddress    string
+	ELAVSDirectoryAddress         string
+	ELRewardsCoordinatorAddress   string
+	ELPermissionControllerAddress string
+	WebAppUrl                     string
+	ProofStoreBaseURL             string
 }

--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -164,34 +163,34 @@ func readAndValidateAcceptAdminConfig(
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &acceptAdminConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		CallerAddress:            callerAddress,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		SignerConfig:             *signerConfig,
-		ChainID:                  chainID,
-		Environment:              environment,
-		OutputFile:               outputFile,
-		OutputType:               outputType,
-		Broadcast:                broadcast,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		CallerAddress:               callerAddress,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		SignerConfig:                *signerConfig,
+		ChainID:                     chainID,
+		Environment:                 environment,
+		OutputFile:                  outputFile,
+		OutputType:                  outputType,
+		Broadcast:                   broadcast,
 	}, nil
 }
 
@@ -226,7 +225,7 @@ func generateAcceptAdminWriter(
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
-				PermissionsControllerAddress: config.PermissionManagerAddress,
+				PermissionsControllerAddress: config.PermissionControllerAddress,
 			},
 			prompter,
 			config.ChainID,

--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"

--- a/pkg/user/admin/add_pending.go
+++ b/pkg/user/admin/add_pending.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"

--- a/pkg/user/admin/add_pending.go
+++ b/pkg/user/admin/add_pending.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -167,36 +166,36 @@ func readAndValidateAddPendingAdminConfig(
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &addPendingAdminConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		AdminAddress:             adminAddress,
-		CallerAddress:            callerAddress,
-		SignerConfig:             *signerConfig,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
-		OutputFile:               outputFile,
-		OutputType:               outputType,
-		Broadcast:                broadcast,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		AdminAddress:                adminAddress,
+		CallerAddress:               callerAddress,
+		SignerConfig:                *signerConfig,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
+		OutputFile:                  outputFile,
+		OutputType:                  outputType,
+		Broadcast:                   broadcast,
 	}, nil
 }
 
@@ -213,7 +212,7 @@ func generateAddPendingAdminWriter(
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
-				PermissionsControllerAddress: config.PermissionManagerAddress,
+				PermissionsControllerAddress: config.PermissionControllerAddress,
 			},
 			prompter,
 			config.ChainID,

--- a/pkg/user/admin/is_admin.go
+++ b/pkg/user/admin/is_admin.go
@@ -73,32 +73,32 @@ func readAndValidateIsAdminConfig(cliContext *cli.Context, logger logging.Logger
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
 	var err error
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &isAdminConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		AdminAddress:             adminAddress,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		AdminAddress:                adminAddress,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
 	}, nil
 }
 
@@ -117,7 +117,7 @@ func generateIsAdminReader(logger logging.Logger, config *isAdminConfig) (IsAdmi
 	}
 	elReader, err := elcontracts.NewReaderFromConfig(
 		elcontracts.Config{
-			PermissionsControllerAddress: config.PermissionManagerAddress,
+			PermissionsControllerAddress: config.PermissionControllerAddress,
 		},
 		ethClient,
 		logger,

--- a/pkg/user/admin/is_pending.go
+++ b/pkg/user/admin/is_pending.go
@@ -81,32 +81,32 @@ func readAndValidateIsPendingAdminConfig(
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
 	var err error
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &isPendingAdminConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		PendingAdminAddress:      pendingAdminAddress,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		PendingAdminAddress:         pendingAdminAddress,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
 	}, nil
 }
 
@@ -125,7 +125,7 @@ func generateIsPendingAdminReader(logger logging.Logger, config *isPendingAdminC
 	}
 	elReader, err := elcontracts.NewReaderFromConfig(
 		elcontracts.Config{
-			PermissionsControllerAddress: config.PermissionManagerAddress,
+			PermissionsControllerAddress: config.PermissionControllerAddress,
 		},
 		ethClient,
 		logger,

--- a/pkg/user/admin/list.go
+++ b/pkg/user/admin/list.go
@@ -83,31 +83,31 @@ func readAndValidateListAdminsConfig(cliContext *cli.Context, logger logging.Log
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	permissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
 	var err error
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(permissionControllerAddress) {
+		permissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		permissionControllerAddress,
 	)
 
 	return &listAdminsConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		PermissionControllerAddress: gethcommon.HexToAddress(permissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
 	}, nil
 }
 
@@ -118,7 +118,7 @@ func generateListAdminsReader(logger logging.Logger, config *listAdminsConfig) (
 	}
 	elReader, err := elcontracts.NewReaderFromConfig(
 		elcontracts.Config{
-			PermissionsControllerAddress: config.PermissionManagerAddress,
+			PermissionsControllerAddress: config.PermissionControllerAddress,
 		},
 		ethClient,
 		logger,

--- a/pkg/user/admin/list_pending.go
+++ b/pkg/user/admin/list_pending.go
@@ -88,31 +88,31 @@ func readAndValidateListPendingAdminsConfig(
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	permissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
 	var err error
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(permissionControllerAddress) {
+		permissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		permissionControllerAddress,
 	)
 
 	return &listPendingAdminsConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		PermissionControllerAddress: gethcommon.HexToAddress(permissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
 	}, nil
 }
 
@@ -126,7 +126,7 @@ func generateListPendingAdminsReader(
 	}
 	elReader, err := elcontracts.NewReaderFromConfig(
 		elcontracts.Config{
-			PermissionsControllerAddress: config.PermissionManagerAddress,
+			PermissionsControllerAddress: config.PermissionControllerAddress,
 		},
 		ethClient,
 		logger,

--- a/pkg/user/admin/remove.go
+++ b/pkg/user/admin/remove.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"

--- a/pkg/user/admin/remove.go
+++ b/pkg/user/admin/remove.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -165,36 +164,36 @@ func readAndValidateRemoveAdminConfig(
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &removeAdminConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		AdminAddress:             adminAddress,
-		CallerAddress:            callerAddress,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		SignerConfig:             *signerConfig,
-		ChainID:                  chainID,
-		Environment:              environment,
-		OutputFile:               outputFile,
-		OutputType:               outputType,
-		Broadcast:                broadcast,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		AdminAddress:                adminAddress,
+		CallerAddress:               callerAddress,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		SignerConfig:                *signerConfig,
+		ChainID:                     chainID,
+		Environment:                 environment,
+		OutputFile:                  outputFile,
+		OutputType:                  outputType,
+		Broadcast:                   broadcast,
 	}, nil
 }
 
@@ -211,7 +210,7 @@ func generateRemoveAdminWriter(
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
-				PermissionsControllerAddress: config.PermissionManagerAddress,
+				PermissionsControllerAddress: config.PermissionControllerAddress,
 			},
 			prompter,
 			config.ChainID,

--- a/pkg/user/admin/remove_pending.go
+++ b/pkg/user/admin/remove_pending.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"

--- a/pkg/user/admin/remove_pending.go
+++ b/pkg/user/admin/remove_pending.go
@@ -3,7 +3,6 @@ package admin
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -165,36 +164,36 @@ func readAndValidateRemovePendingAdminConfig(
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &removePendingAdminConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		AdminAddress:             adminAddress,
-		CallerAddress:            callerAddress,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		SignerConfig:             *signerConfig,
-		ChainID:                  chainID,
-		Environment:              environment,
-		OutputFile:               outputFile,
-		OutputType:               outputType,
-		Broadcast:                broadcast,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		AdminAddress:                adminAddress,
+		CallerAddress:               callerAddress,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		SignerConfig:                *signerConfig,
+		ChainID:                     chainID,
+		Environment:                 environment,
+		OutputFile:                  outputFile,
+		OutputType:                  outputType,
+		Broadcast:                   broadcast,
 	}, nil
 }
 
@@ -211,7 +210,7 @@ func generateRemovePendingAdminWriter(
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
-				PermissionsControllerAddress: config.PermissionManagerAddress,
+				PermissionsControllerAddress: config.PermissionControllerAddress,
 			},
 			prompter,
 			config.ChainID,

--- a/pkg/user/admin/types.go
+++ b/pkg/user/admin/types.go
@@ -8,98 +8,98 @@ import (
 )
 
 type listPendingAdminsConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	PermissionManagerAddress gethcommon.Address
-	ChainID                  *big.Int
-	Environment              string
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
+	ChainID                     *big.Int
+	Environment                 string
 }
 
 type listAdminsConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	PermissionManagerAddress gethcommon.Address
-	ChainID                  *big.Int
-	Environment              string
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
+	ChainID                     *big.Int
+	Environment                 string
 }
 
 type isPendingAdminConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	PendingAdminAddress      gethcommon.Address
-	PermissionManagerAddress gethcommon.Address
-	ChainID                  *big.Int
-	Environment              string
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	PendingAdminAddress         gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
+	ChainID                     *big.Int
+	Environment                 string
 }
 
 type isAdminConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	AdminAddress             gethcommon.Address
-	PermissionManagerAddress gethcommon.Address
-	ChainID                  *big.Int
-	Environment              string
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	AdminAddress                gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
+	ChainID                     *big.Int
+	Environment                 string
 }
 
 type acceptAdminConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	CallerAddress            gethcommon.Address
-	PermissionManagerAddress gethcommon.Address
-	SignerConfig             types.SignerConfig
-	ChainID                  *big.Int
-	Environment              string
-	OutputFile               string
-	OutputType               string
-	Broadcast                bool
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	CallerAddress               gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
+	SignerConfig                types.SignerConfig
+	ChainID                     *big.Int
+	Environment                 string
+	OutputFile                  string
+	OutputType                  string
+	Broadcast                   bool
 }
 
 type addPendingAdminConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	AdminAddress             gethcommon.Address
-	CallerAddress            gethcommon.Address
-	PermissionManagerAddress gethcommon.Address
-	SignerConfig             types.SignerConfig
-	ChainID                  *big.Int
-	Environment              string
-	OutputFile               string
-	OutputType               string
-	Broadcast                bool
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	AdminAddress                gethcommon.Address
+	CallerAddress               gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
+	SignerConfig                types.SignerConfig
+	ChainID                     *big.Int
+	Environment                 string
+	OutputFile                  string
+	OutputType                  string
+	Broadcast                   bool
 }
 
 type removeAdminConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	AdminAddress             gethcommon.Address
-	CallerAddress            gethcommon.Address
-	PermissionManagerAddress gethcommon.Address
-	SignerConfig             types.SignerConfig
-	ChainID                  *big.Int
-	Environment              string
-	OutputFile               string
-	OutputType               string
-	Broadcast                bool
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	AdminAddress                gethcommon.Address
+	CallerAddress               gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
+	SignerConfig                types.SignerConfig
+	ChainID                     *big.Int
+	Environment                 string
+	OutputFile                  string
+	OutputType                  string
+	Broadcast                   bool
 }
 
 type removePendingAdminConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	AdminAddress             gethcommon.Address
-	CallerAddress            gethcommon.Address
-	PermissionManagerAddress gethcommon.Address
-	SignerConfig             types.SignerConfig
-	ChainID                  *big.Int
-	Environment              string
-	OutputFile               string
-	OutputType               string
-	Broadcast                bool
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	AdminAddress                gethcommon.Address
+	CallerAddress               gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
+	SignerConfig                types.SignerConfig
+	ChainID                     *big.Int
+	Environment                 string
+	OutputFile                  string
+	OutputType                  string
+	Broadcast                   bool
 }

--- a/pkg/user/appointee/can_call.go
+++ b/pkg/user/appointee/can_call.go
@@ -84,33 +84,33 @@ func readAndValidateCanCallConfig(cliContext *cli.Context, logger logging.Logger
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &canCallConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		AppointeeAddress:         appointeeAddress,
-		Target:                   target,
-		Selector:                 selectorBytes,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		AppointeeAddress:            appointeeAddress,
+		Target:                      target,
+		Selector:                    selectorBytes,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
 	}, nil
 }
 
@@ -124,7 +124,7 @@ func generateCanCallReader(
 	}
 	elReader, err := elcontracts.NewReaderFromConfig(
 		elcontracts.Config{
-			PermissionsControllerAddress: config.PermissionManagerAddress,
+			PermissionsControllerAddress: config.PermissionControllerAddress,
 		},
 		ethClient,
 		logger,

--- a/pkg/user/appointee/list.go
+++ b/pkg/user/appointee/list.go
@@ -102,32 +102,32 @@ func readAndValidateListAppointeesConfig(
 
 	chainID := utils.NetworkNameToChainId(network)
 	cliContext.App.Metadata["network"] = chainID.String()
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &listAppointeesConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		Target:                   target,
-		Selector:                 selectorBytes,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		Target:                      target,
+		Selector:                    selectorBytes,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
 	}, nil
 }
 
@@ -138,7 +138,7 @@ func generateListAppointeesReader(logger logging.Logger, config *listAppointeesC
 	}
 	elReader, err := elcontracts.NewReaderFromConfig(
 		elcontracts.Config{
-			PermissionsControllerAddress: config.PermissionManagerAddress,
+			PermissionsControllerAddress: config.PermissionControllerAddress,
 		},
 		ethClient,
 		logger,

--- a/pkg/user/appointee/list_permissions.go
+++ b/pkg/user/appointee/list_permissions.go
@@ -83,32 +83,32 @@ func readAndValidateListAppointeePermissionsConfig(
 	}
 
 	chainID := utils.NetworkNameToChainId(network)
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
 	var err error
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &listAppointeePermissionsConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		AppointeeAddress:         appointeeAddress,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		AppointeeAddress:            appointeeAddress,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
 	}, nil
 }
 
@@ -132,7 +132,7 @@ func generateListAppointeePermissionsReader(
 	}
 	elReader, err := elcontracts.NewReaderFromConfig(
 		elcontracts.Config{
-			PermissionsControllerAddress: config.PermissionManagerAddress,
+			PermissionsControllerAddress: config.PermissionControllerAddress,
 		},
 		ethClient,
 		logger,

--- a/pkg/user/appointee/remove.go
+++ b/pkg/user/appointee/remove.go
@@ -3,6 +3,7 @@ package appointee
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"

--- a/pkg/user/appointee/remove.go
+++ b/pkg/user/appointee/remove.go
@@ -3,7 +3,6 @@ package appointee
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -159,7 +158,7 @@ func generateRemoveAppointeePermissionWriter(
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
-				PermissionsControllerAddress: config.PermissionManagerAddress,
+				PermissionsControllerAddress: config.PermissionControllerAddress,
 			},
 			prompter,
 			config.ChainID,
@@ -198,37 +197,37 @@ func readAndValidateRemoveConfig(cliContext *cli.Context, logger logging.Logger)
 
 	chainID := utils.NetworkNameToChainId(network)
 	cliContext.App.Metadata["network"] = chainID.String()
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &removeConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		AppointeeAddress:         appointeeAddress,
-		CallerAddress:            callerAddress,
-		Target:                   target,
-		Selector:                 selectorBytes,
-		SignerConfig:             *signerConfig,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
-		Broadcast:                broadcast,
-		OutputType:               outputType,
-		OutputFile:               outputFile,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		AppointeeAddress:            appointeeAddress,
+		CallerAddress:               callerAddress,
+		Target:                      target,
+		Selector:                    selectorBytes,
+		SignerConfig:                *signerConfig,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
+		Broadcast:                   broadcast,
+		OutputType:                  outputType,
+		OutputFile:                  outputFile,
 	}, nil
 }
 

--- a/pkg/user/appointee/set.go
+++ b/pkg/user/appointee/set.go
@@ -3,6 +3,7 @@ package appointee
 import (
 	"context"
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"

--- a/pkg/user/appointee/set.go
+++ b/pkg/user/appointee/set.go
@@ -3,7 +3,6 @@ package appointee
 import (
 	"context"
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/user"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -162,7 +161,7 @@ func generateSetAppointeePermissionWriter(
 			&config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
-				PermissionsControllerAddress: config.PermissionManagerAddress,
+				PermissionsControllerAddress: config.PermissionControllerAddress,
 			},
 			prompter,
 			config.ChainID,
@@ -201,38 +200,38 @@ func readAndValidateSetConfig(cliContext *cli.Context, logger logging.Logger) (*
 
 	chainID := utils.NetworkNameToChainId(network)
 	cliContext.App.Metadata["network"] = chainID.String()
-	permissionManagerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
+	PermissionControllerAddress := cliContext.String(PermissionControllerAddressFlag.Name)
 
-	if common.IsEmptyString(permissionManagerAddress) {
-		permissionManagerAddress, err = common.GetPermissionManagerAddress(utils.NetworkNameToChainId(network))
+	if common.IsEmptyString(PermissionControllerAddress) {
+		PermissionControllerAddress, err = common.GetPermissionControllerAddress(utils.NetworkNameToChainId(network))
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	logger.Debugf(
-		"Env: %s, network: %s, chain ID: %s, PermissionManager address: %s",
+		"Env: %s, network: %s, chain ID: %s, PermissionController address: %s",
 		environment,
 		network,
 		chainID,
-		permissionManagerAddress,
+		PermissionControllerAddress,
 	)
 
 	return &setConfig{
-		Network:                  network,
-		RPCUrl:                   ethRpcUrl,
-		AccountAddress:           accountAddress,
-		AppointeeAddress:         appointeeAddress,
-		CallerAddress:            callerAddress,
-		Target:                   target,
-		Selector:                 selectorBytes,
-		SignerConfig:             *signerConfig,
-		PermissionManagerAddress: gethcommon.HexToAddress(permissionManagerAddress),
-		ChainID:                  chainID,
-		Environment:              environment,
-		OutputFile:               outputFile,
-		OutputType:               outputType,
-		Broadcast:                broadcast,
+		Network:                     network,
+		RPCUrl:                      ethRpcUrl,
+		AccountAddress:              accountAddress,
+		AppointeeAddress:            appointeeAddress,
+		CallerAddress:               callerAddress,
+		Target:                      target,
+		Selector:                    selectorBytes,
+		SignerConfig:                *signerConfig,
+		PermissionControllerAddress: gethcommon.HexToAddress(PermissionControllerAddress),
+		ChainID:                     chainID,
+		Environment:                 environment,
+		OutputFile:                  outputFile,
+		OutputType:                  outputType,
+		Broadcast:                   broadcast,
 	}, nil
 }
 

--- a/pkg/user/appointee/types.go
+++ b/pkg/user/appointee/types.go
@@ -8,68 +8,68 @@ import (
 )
 
 type canCallConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	AppointeeAddress         gethcommon.Address
-	Target                   gethcommon.Address
-	Selector                 [4]byte
-	PermissionManagerAddress gethcommon.Address
-	ChainID                  *big.Int
-	Environment              string
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	AppointeeAddress            gethcommon.Address
+	Target                      gethcommon.Address
+	Selector                    [4]byte
+	PermissionControllerAddress gethcommon.Address
+	ChainID                     *big.Int
+	Environment                 string
 }
 
 type listAppointeesConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	Target                   gethcommon.Address
-	Selector                 [4]byte
-	PermissionManagerAddress gethcommon.Address
-	ChainID                  *big.Int
-	Environment              string
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	Target                      gethcommon.Address
+	Selector                    [4]byte
+	PermissionControllerAddress gethcommon.Address
+	ChainID                     *big.Int
+	Environment                 string
 }
 
 type listAppointeePermissionsConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	AppointeeAddress         gethcommon.Address
-	PermissionManagerAddress gethcommon.Address
-	ChainID                  *big.Int
-	Environment              string
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	AppointeeAddress            gethcommon.Address
+	PermissionControllerAddress gethcommon.Address
+	ChainID                     *big.Int
+	Environment                 string
 }
 
 type removeConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	AppointeeAddress         gethcommon.Address
-	CallerAddress            gethcommon.Address
-	Target                   gethcommon.Address
-	SignerConfig             types.SignerConfig
-	Selector                 [4]byte
-	PermissionManagerAddress gethcommon.Address
-	ChainID                  *big.Int
-	Environment              string
-	OutputFile               string
-	OutputType               string
-	Broadcast                bool
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	AppointeeAddress            gethcommon.Address
+	CallerAddress               gethcommon.Address
+	Target                      gethcommon.Address
+	SignerConfig                types.SignerConfig
+	Selector                    [4]byte
+	PermissionControllerAddress gethcommon.Address
+	ChainID                     *big.Int
+	Environment                 string
+	OutputFile                  string
+	OutputType                  string
+	Broadcast                   bool
 }
 
 type setConfig struct {
-	Network                  string
-	RPCUrl                   string
-	AccountAddress           gethcommon.Address
-	AppointeeAddress         gethcommon.Address
-	CallerAddress            gethcommon.Address
-	Target                   gethcommon.Address
-	SignerConfig             types.SignerConfig
-	Selector                 [4]byte
-	PermissionManagerAddress gethcommon.Address
-	ChainID                  *big.Int
-	Environment              string
-	OutputFile               string
-	OutputType               string
-	Broadcast                bool
+	Network                     string
+	RPCUrl                      string
+	AccountAddress              gethcommon.Address
+	AppointeeAddress            gethcommon.Address
+	CallerAddress               gethcommon.Address
+	Target                      gethcommon.Address
+	SignerConfig                types.SignerConfig
+	Selector                    [4]byte
+	PermissionControllerAddress gethcommon.Address
+	ChainID                     *big.Int
+	Environment                 string
+	OutputFile                  string
+	OutputType                  string
+	Broadcast                   bool
 }


### PR DESCRIPTION
Rename of PermissionManager => PermissionController.

### What Changed?
 - Renaming `PermissionManager` => `PermissionController` to match the contract name.
 - Adding anvil `PermissionController` address to helper.
