### PR TITLE
Bugfix/rewards uam support

### DIFF
--- a/pkg/internal/command/BaseCommand.go
+++ b/pkg/internal/command/BaseCommand.go
@@ -1,0 +1,9 @@
+package command
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+type BaseCommand interface {
+	Execute(c *cli.Context) error
+}

--- a/pkg/internal/command/NewWriteableCallDataCommand.go
+++ b/pkg/internal/command/NewWriteableCallDataCommand.go
@@ -1,0 +1,43 @@
+package command
+
+import (
+	"sort"
+
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
+
+	"github.com/urfave/cli/v2"
+)
+
+func NewWriteableCallDataCommand(
+	baseCmd BaseCommand,
+	name string,
+	usage string,
+	usageText string,
+	description string,
+	commandFlags []cli.Flag,
+) *cli.Command {
+	withWriteFlags := append(commandFlags, flags.WriteFlags...)
+	allFlags := append(withWriteFlags, flags.GetSignerFlags()...)
+	sort.Sort(cli.FlagsByName(allFlags))
+
+	command := &cli.Command{
+		Name:  name,
+		Usage: usage,
+		Flags: allFlags,
+		Action: func(cCtx *cli.Context) error {
+			return baseCmd.Execute(cCtx)
+		},
+		After: telemetry.AfterRunAction(),
+	}
+
+	if usageText != "" {
+		command.UsageText = usageText
+	}
+
+	if description != "" {
+		command.Description = description
+	}
+
+	return command
+}

--- a/pkg/internal/common/flags/write.go
+++ b/pkg/internal/common/flags/write.go
@@ -1,0 +1,10 @@
+package flags
+
+import "github.com/urfave/cli/v2"
+
+var WriteFlags = []cli.Flag{
+	&OutputFileFlag,
+	&OutputTypeFlag,
+	&CallerAddressFlag,
+	&BroadcastFlag,
+}

--- a/pkg/internal/common/helper.go
+++ b/pkg/internal/common/helper.go
@@ -585,6 +585,24 @@ func ValidateAndConvertSelectorString(selector string) ([4]byte, error) {
 	return selectorBytes, nil
 }
 
+func PopulateCallerAddress(
+	cliContext *cli.Context,
+	logger eigensdkLogger.Logger,
+	defaultAddress common.Address,
+) common.Address {
+	// TODO: these are copied across both callers of this method. Will clean this up in the CLI refactor of flags.
+	callerAddress := cliContext.String(flags.CallerAddressFlag.Name)
+	if IsEmptyString(callerAddress) {
+		logger.Infof(
+			"User access management delegation using caller address not invoked. Signing with: %s",
+			defaultAddress,
+		)
+
+		return defaultAddress
+	}
+	return common.HexToAddress(callerAddress)
+}
+
 func GetEnvFromNetwork(network string) string {
 	switch network {
 	case utils.HoleskyNetworkName:

--- a/pkg/operator.go
+++ b/pkg/operator.go
@@ -25,8 +25,8 @@ func OperatorCmd(p utils.Prompter) *cli.Command {
 			operator.SetOperatorSetSplitCmd(p),
 			operator.GetOperatorSetSplitCmd(p),
 			operator.AllocationsCmd(p),
-			operator.DeregisterCommand(p),
-			operator.RegisterOperatorSetsCommand(p),
+			operator.NewDeregisterCommand(p),
+			operator.NewRegisterOperatorSetsCommand(p),
 		},
 	}
 

--- a/pkg/operator.go
+++ b/pkg/operator.go
@@ -18,7 +18,7 @@ func OperatorCmd(p utils.Prompter) *cli.Command {
 			operator.UpdateCmd(p),
 			operator.UpdateMetadataURICmd(p),
 			operator.GetApprovalCmd(p),
-			operator.NewSetOperatorSplitCmd(p),
+			operator.NewSetOperatorSplitCmd(p, false, false),
 			operator.GetOperatorSplitCmd(p),
 			operator.GetOperatorPISplitCmd(p),
 			operator.SetOperatorPISplitCmd(p),

--- a/pkg/operator.go
+++ b/pkg/operator.go
@@ -18,7 +18,7 @@ func OperatorCmd(p utils.Prompter) *cli.Command {
 			operator.UpdateCmd(p),
 			operator.UpdateMetadataURICmd(p),
 			operator.GetApprovalCmd(p),
-			operator.SetOperatorSplitCmd(p),
+			operator.NewSetOperatorSplitCmd(p),
 			operator.GetOperatorSplitCmd(p),
 			operator.GetOperatorPISplitCmd(p),
 			operator.SetOperatorPISplitCmd(p),

--- a/pkg/operator.go
+++ b/pkg/operator.go
@@ -25,8 +25,8 @@ func OperatorCmd(p utils.Prompter) *cli.Command {
 			operator.SetOperatorSetSplitCmd(p),
 			operator.GetOperatorSetSplitCmd(p),
 			operator.AllocationsCmd(p),
-			operator.NewDeregisterCommand(p),
-			operator.NewRegisterOperatorSetsCommand(p),
+			operator.NewDeregisterOperatorSetsCmd(p),
+			operator.NewRegisterOperatorSetsCmd(p),
 		},
 	}
 

--- a/pkg/operator/deregister_operator_sets.go
+++ b/pkg/operator/deregister_operator_sets.go
@@ -2,12 +2,10 @@ package operator
 
 import (
 	"fmt"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
 	"math"
 	"strings"
 
-	"sort"
-
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
@@ -219,7 +217,7 @@ func readAndValidateDeregisterConfig(cCtx *cli.Context, logger logging.Logger) (
 }
 
 func getDeregistrationFlags() []cli.Flag {
-	baseFlags := []cli.Flag{
+	return []cli.Flag{
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,
@@ -230,7 +228,4 @@ func getDeregistrationFlags() []cli.Flag {
 		&flags.DelegationManagerAddressFlag,
 		&flags.SilentFlag,
 	}
-
-	sort.Sort(cli.FlagsByName(baseFlags))
-	return baseFlags
 }

--- a/pkg/operator/deregister_operator_sets.go
+++ b/pkg/operator/deregister_operator_sets.go
@@ -25,7 +25,7 @@ type DeregisterOperatorSetsCmd struct {
 	prompter utils.Prompter
 }
 
-func DeregisterCommand(p utils.Prompter) *cli.Command {
+func NewDeregisterCommand(p utils.Prompter) *cli.Command {
 	delegateCommand := &DeregisterOperatorSetsCmd{prompter: p}
 	deregisterCmd := command.NewWriteableCallDataCommand(
 		delegateCommand,

--- a/pkg/operator/deregister_operator_sets.go
+++ b/pkg/operator/deregister_operator_sets.go
@@ -25,7 +25,7 @@ type DeregisterOperatorSetsCmd struct {
 	prompter utils.Prompter
 }
 
-func NewDeregisterCommand(p utils.Prompter) *cli.Command {
+func NewDeregisterOperatorSetsCmd(p utils.Prompter) *cli.Command {
 	delegateCommand := &DeregisterOperatorSetsCmd{prompter: p}
 	deregisterCmd := command.NewWriteableCallDataCommand(
 		delegateCommand,

--- a/pkg/operator/deregister_operator_sets.go
+++ b/pkg/operator/deregister_operator_sets.go
@@ -231,7 +231,6 @@ func getDeregistrationFlags() []cli.Flag {
 		&flags.SilentFlag,
 	}
 
-	allFlags := append(baseFlags, flags.GetSignerFlags()...)
-	sort.Sort(cli.FlagsByName(allFlags))
-	return allFlags
+	sort.Sort(cli.FlagsByName(baseFlags))
+	return baseFlags
 }

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -22,7 +22,7 @@ type RegisterOperatorSetCmd struct {
 	prompter utils.Prompter
 }
 
-func NewRegisterOperatorSetsCommand(p utils.Prompter) *cli.Command {
+func NewRegisterOperatorSetsCmd(p utils.Prompter) *cli.Command {
 	delegateCommand := &RegisterOperatorSetCmd{p}
 	registerOperatorSetCmd := command.NewWriteableCallDataCommand(
 		delegateCommand,

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -2,11 +2,11 @@ package operator
 
 import (
 	"fmt"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
@@ -20,27 +20,25 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func RegisterOperatorSetsCommand(p utils.Prompter) *cli.Command {
-	registerOperatorSetsCmd := &cli.Command{
-		Name:      "register-operator-sets",
-		Usage:     "register operator from specified operator sets",
-		UsageText: "register-operator-sets [flags]",
-		Description: `
-register operator sets for operator.
-
-To find what operator set you are registered for, use the 'eigenlayer operator allocations show' command.
-
-`,
-		Flags: getRegistrationFlags(),
-		After: telemetry.AfterRunAction(),
-		Action: func(context *cli.Context) error {
-			return registerOperatorSetsAction(context, p)
-		},
-	}
-	return registerOperatorSetsCmd
+type RegisterOperatorSetCmd struct {
+	prompter utils.Prompter
 }
 
-func registerOperatorSetsAction(cCtx *cli.Context, p utils.Prompter) error {
+func RegisterOperatorSetsCommand(p utils.Prompter) *cli.Command {
+	delegateCommand := &RegisterOperatorSetCmd{p}
+	registerOperatorSetCmd := command.NewWriteableCallDataCommand(
+		delegateCommand,
+		"register-operator-sets",
+		"register operator from specified operator sets",
+		"register-operator-sets [flags]",
+		"",
+		getRegistrationFlags(),
+	)
+
+	return registerOperatorSetCmd
+}
+
+func (r RegisterOperatorSetCmd) Execute(cCtx *cli.Context) error {
 	ctx := cCtx.Context
 	logger := common.GetLogger(cCtx)
 
@@ -68,7 +66,7 @@ func registerOperatorSetsAction(cCtx *cli.Context, p utils.Prompter) error {
 			elcontracts.Config{
 				DelegationManagerAddress: config.delegationManagerAddress,
 			},
-			p,
+			r.prompter,
 			config.chainID,
 			logger,
 		)
@@ -96,7 +94,7 @@ func registerOperatorSetsAction(cCtx *cli.Context, p utils.Prompter) error {
 		if err != nil {
 			return err
 		}
-		// If operator is a smart contract, we can't estimate gas using geth
+		// If caller is a smart contract, we can't estimate gas using geth
 		// since balance of contract can be 0, as it can be called by an EOA
 		// to claim. So we hardcode the gas limit to 150_000 so that we can
 		// create unsigned tx without gas limit estimation from contract bindings
@@ -158,11 +156,7 @@ func readAndValidateRegisterOperatorSetsConfig(cCtx *cli.Context, logger logging
 	isSilent := cCtx.Bool(flags.SilentFlag.Name)
 
 	operatorAddress := cCtx.String(flags.OperatorAddressFlag.Name)
-	callerAddress := cCtx.String(flags.CallerAddressFlag.Name)
-	if common.IsEmptyString(callerAddress) {
-		logger.Infof("Caller address not provided. Using operator address (%s) as caller address", operatorAddress)
-		callerAddress = operatorAddress
-	}
+	callerAddress := common.PopulateCallerAddress(cCtx, logger, gethcommon.HexToAddress(operatorAddress))
 	avsAddress := gethcommon.HexToAddress(cCtx.String(flags.AVSAddressFlag.Name))
 
 	// Get signerConfig
@@ -193,7 +187,7 @@ func readAndValidateRegisterOperatorSetsConfig(cCtx *cli.Context, logger logging
 		avsAddress:               avsAddress,
 		operatorSetIds:           operatorSetIds,
 		operatorAddress:          gethcommon.HexToAddress(operatorAddress),
-		callerAddress:            gethcommon.HexToAddress(callerAddress),
+		callerAddress:            callerAddress,
 		network:                  network,
 		environment:              environment,
 		broadcast:                broadcast,
@@ -214,16 +208,12 @@ func getRegistrationFlags() []cli.Flag {
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,
-		&flags.OutputFileFlag,
-		&flags.OutputTypeFlag,
-		&flags.BroadcastFlag,
 		&flags.VerboseFlag,
 		&flags.AVSAddressFlag,
 		&flags.OperatorAddressFlag,
 		&flags.OperatorSetIdsFlag,
 		&flags.DelegationManagerAddressFlag,
 		&flags.SilentFlag,
-		&flags.CallerAddressFlag,
 	}
 
 	allFlags := append(baseFlags, flags.GetSignerFlags()...)

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -3,8 +3,6 @@ package operator
 import (
 	"fmt"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
-	"sort"
-
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
@@ -204,7 +202,7 @@ func readAndValidateRegisterOperatorSetsConfig(cCtx *cli.Context, logger logging
 }
 
 func getRegistrationFlags() []cli.Flag {
-	baseFlags := []cli.Flag{
+	return []cli.Flag{
 		&flags.NetworkFlag,
 		&flags.EnvironmentFlag,
 		&flags.ETHRpcUrlFlag,
@@ -215,7 +213,4 @@ func getRegistrationFlags() []cli.Flag {
 		&flags.DelegationManagerAddressFlag,
 		&flags.SilentFlag,
 	}
-
-	sort.Sort(cli.FlagsByName(baseFlags))
-	return baseFlags
 }

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -22,7 +22,7 @@ type RegisterOperatorSetCmd struct {
 	prompter utils.Prompter
 }
 
-func RegisterOperatorSetsCommand(p utils.Prompter) *cli.Command {
+func NewRegisterOperatorSetsCommand(p utils.Prompter) *cli.Command {
 	delegateCommand := &RegisterOperatorSetCmd{p}
 	registerOperatorSetCmd := command.NewWriteableCallDataCommand(
 		delegateCommand,
@@ -153,8 +153,8 @@ func readAndValidateRegisterOperatorSetsConfig(cCtx *cli.Context, logger logging
 	broadcast := cCtx.Bool(flags.BroadcastFlag.Name)
 	isSilent := cCtx.Bool(flags.SilentFlag.Name)
 
-	operatorAddress := cCtx.String(flags.OperatorAddressFlag.Name)
-	callerAddress := common.PopulateCallerAddress(cCtx, logger, gethcommon.HexToAddress(operatorAddress))
+	operatorAddress := gethcommon.HexToAddress(cCtx.String(flags.OperatorAddressFlag.Name))
+	callerAddress := common.PopulateCallerAddress(cCtx, logger, operatorAddress)
 	avsAddress := gethcommon.HexToAddress(cCtx.String(flags.AVSAddressFlag.Name))
 
 	// Get signerConfig
@@ -184,7 +184,7 @@ func readAndValidateRegisterOperatorSetsConfig(cCtx *cli.Context, logger logging
 	config := &RegisterConfig{
 		avsAddress:               avsAddress,
 		operatorSetIds:           operatorSetIds,
-		operatorAddress:          gethcommon.HexToAddress(operatorAddress),
+		operatorAddress:          operatorAddress,
 		callerAddress:            callerAddress,
 		network:                  network,
 		environment:              environment,

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -216,7 +216,6 @@ func getRegistrationFlags() []cli.Flag {
 		&flags.SilentFlag,
 	}
 
-	allFlags := append(baseFlags, flags.GetSignerFlags()...)
-	sort.Sort(cli.FlagsByName(allFlags))
-	return allFlags
+	sort.Sort(cli.FlagsByName(baseFlags))
+	return baseFlags
 }

--- a/pkg/operator/set_operator_split.go
+++ b/pkg/operator/set_operator_split.go
@@ -3,8 +3,6 @@ package operator
 import (
 	"fmt"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
-	"sort"
-
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/operator/split"
@@ -157,7 +155,7 @@ func (s SetOperatorSplitCmd) Execute(cCtx *cli.Context) error {
 }
 
 func getSetOperatorSplitFlags() []cli.Flag {
-	baseFlags := []cli.Flag{
+	return []cli.Flag{
 		&flags.NetworkFlag,
 		&flags.ETHRpcUrlFlag,
 		&flags.OperatorAddressFlag,
@@ -166,9 +164,6 @@ func getSetOperatorSplitFlags() []cli.Flag {
 		&split.AVSAddressFlag,
 		&flags.SilentFlag,
 	}
-
-	sort.Sort(cli.FlagsByName(baseFlags))
-	return baseFlags
 }
 
 func readAndValidateSetOperatorSplitConfig(

--- a/pkg/operator/set_operator_split.go
+++ b/pkg/operator/set_operator_split.go
@@ -167,9 +167,8 @@ func getSetOperatorSplitFlags() []cli.Flag {
 		&flags.SilentFlag,
 	}
 
-	allFlags := append(baseFlags, flags.GetSignerFlags()...)
-	sort.Sort(cli.FlagsByName(allFlags))
-	return allFlags
+	sort.Sort(cli.FlagsByName(baseFlags))
+	return baseFlags
 }
 
 func readAndValidateSetOperatorSplitConfig(

--- a/pkg/operator/split/types.go
+++ b/pkg/operator/split/types.go
@@ -16,6 +16,7 @@ type SetOperatorAVSSplitConfig struct {
 	Broadcast                 bool
 	OperatorAddress           gethcommon.Address
 	AVSAddress                gethcommon.Address
+	CallerAddress             gethcommon.Address
 	Split                     uint16
 	OutputType                string
 	OutputFile                string

--- a/pkg/rewards.go
+++ b/pkg/rewards.go
@@ -11,8 +11,8 @@ func RewardsCmd(p utils.Prompter) *cli.Command {
 		Name:  "rewards",
 		Usage: "Execute onchain operations for the rewards",
 		Subcommands: []*cli.Command{
-			rewards.ClaimCmd(p),
-			rewards.SetClaimerCmd(p),
+			rewards.NewClaimCmd(p),
+			rewards.NewSetClaimerCmd(p),
 			rewards.ShowCmd(p),
 		},
 	}

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/yaml.v2"
 	"math/big"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
@@ -66,7 +65,7 @@ func NewClaimCmd(p utils.Prompter) *cli.Command {
 }
 
 func getClaimFlags() []cli.Flag {
-	baseFlags := []cli.Flag{
+	return []cli.Flag{
 		&flags.NetworkFlag,
 		&flags.ETHRpcUrlFlag,
 		&EarnerAddressFlag,
@@ -81,8 +80,6 @@ func getClaimFlags() []cli.Flag {
 		&flags.SilentFlag,
 		&flags.BatchClaimFile,
 	}
-	sort.Sort(cli.FlagsByName(baseFlags))
-	return baseFlags
 }
 
 func convertSidecarProofToContractProof(

--- a/pkg/rewards/claim.go
+++ b/pkg/rewards/claim.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"math/big"
 	"os"
 	"sort"
@@ -17,11 +18,10 @@ import (
 	rewardsV1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/sidecar/v1/rewards"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
-	"gopkg.in/yaml.v2"
 
 	"github.com/Layr-Labs/eigenlayer-rewards-proofs/pkg/distribution"
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
@@ -47,16 +47,20 @@ type elChainReader interface {
 	GetCumulativeClaimed(ctx context.Context, earnerAddress, tokenAddress gethcommon.Address) (*big.Int, error)
 }
 
-func ClaimCmd(p utils.Prompter) *cli.Command {
-	var claimCmd = &cli.Command{
-		Name:  "claim",
-		Usage: "Claim rewards for any earner",
-		Action: func(cCtx *cli.Context) error {
-			return Claim(cCtx, p)
-		},
-		After: telemetry.AfterRunAction(),
-		Flags: getClaimFlags(),
-	}
+type ClaimCmd struct {
+	prompter utils.Prompter
+}
+
+func NewClaimCmd(p utils.Prompter) *cli.Command {
+	delegateCmd := &ClaimCmd{prompter: p}
+	claimCmd := command.NewWriteableCallDataCommand(
+		delegateCmd,
+		"claim",
+		"Claim rewards for any earner",
+		"",
+		"",
+		getClaimFlags(),
+	)
 
 	return claimCmd
 }
@@ -65,9 +69,6 @@ func getClaimFlags() []cli.Flag {
 	baseFlags := []cli.Flag{
 		&flags.NetworkFlag,
 		&flags.ETHRpcUrlFlag,
-		&flags.OutputFileFlag,
-		&flags.OutputTypeFlag,
-		&flags.BroadcastFlag,
 		&EarnerAddressFlag,
 		&EnvironmentFlag,
 		&RecipientAddressFlag,
@@ -80,10 +81,8 @@ func getClaimFlags() []cli.Flag {
 		&flags.SilentFlag,
 		&flags.BatchClaimFile,
 	}
-
-	allFlags := append(baseFlags, flags.GetSignerFlags()...)
-	sort.Sort(cli.FlagsByName(allFlags))
-	return allFlags
+	sort.Sort(cli.FlagsByName(baseFlags))
+	return baseFlags
 }
 
 func convertSidecarProofToContractProof(
@@ -258,7 +257,7 @@ func generateClaimPayload(
 	return proof.Proof, nil
 }
 
-func Claim(cCtx *cli.Context, p utils.Prompter) error {
+func (c ClaimCmd) Execute(cCtx *cli.Context) error {
 	ctx := cCtx.Context
 	logger := common.GetLogger(cCtx)
 
@@ -296,7 +295,7 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 	}
 
 	if config.BatchClaimFile != "" {
-		return batchClaim(ctx, logger, ethClient, elReader, config, p, rootIndex, sidecarClient, blockHeight)
+		return batchClaim(ctx, logger, ethClient, elReader, config, c.prompter, rootIndex, sidecarClient, blockHeight)
 	}
 
 	proof, err := generateClaimPayload(
@@ -315,7 +314,7 @@ func Claim(cCtx *cli.Context, p utils.Prompter) error {
 	}
 
 	proofs := []*rewardsV1.Proof{proof}
-	err = broadcastClaims(config, ethClient, logger, p, ctx, proofs)
+	err = broadcastClaims(config, ethClient, logger, c.prompter, ctx, proofs)
 
 	return err
 }
@@ -340,7 +339,7 @@ func broadcastClaims(
 
 	if config.Broadcast {
 		eLWriter, err := common.GetELWriter(
-			config.ClaimerAddress,
+			config.CallerAddress,
 			config.SignerConfig,
 			ethClient,
 			elcontracts.Config{
@@ -371,7 +370,7 @@ func broadcastClaims(
 		logger.Infof("Claim transaction submitted successfully")
 		common.PrintTransactionInfo(receipt.TxHash.String(), config.ChainID)
 	} else {
-		noSendTxOpts := common.GetNoSendTxOpts(config.ClaimerAddress)
+		noSendTxOpts := common.GetNoSendTxOpts(config.CallerAddress)
 		_, _, contractBindings, err := elcontracts.BuildClients(elcontracts.Config{
 			RewardsCoordinatorAddress: config.RewardsCoordinatorAddress,
 		}, ethClient, nil, logger, nil)
@@ -379,12 +378,12 @@ func broadcastClaims(
 			return err
 		}
 
-		// If claimer is a smart contract, we can't estimate gas using geth
+		// If caller is a smart contract, we can't estimate gas using geth
 		// since balance of contract can be 0, as it can be called by an EOA
 		// to claim. So we hardcode the gas limit to 150_000 so that we can
 		// create unsigned tx without gas limit estimation from contract bindings
-		if common.IsSmartContractAddress(config.ClaimerAddress, ethClient) {
-			// Claimer is a smart contract
+		if common.IsSmartContractAddress(config.CallerAddress, ethClient) {
+			// Caller is a smart contract
 			noSendTxOpts.GasLimit = 150_000
 		}
 		var unsignedTx *types.Transaction
@@ -582,6 +581,7 @@ func readAndValidateClaimConfig(cCtx *cli.Context, logger logging.Logger) (*Clai
 	tokenAddresses := cCtx.String(TokenAddressesFlag.Name)
 	splitTokenAddresses := strings.Split(tokenAddresses, ",")
 	validTokenAddresses := getValidHexAddresses(splitTokenAddresses)
+	callerAddress := common.PopulateCallerAddress(cCtx, logger, earnerAddress)
 	rewardsCoordinatorAddress := cCtx.String(RewardsCoordinatorAddressFlag.Name)
 	isSilent := cCtx.Bool(flags.SilentFlag.Name)
 	batchClaimFile := cCtx.String(flags.BatchClaimFile.Name)
@@ -622,7 +622,7 @@ func readAndValidateClaimConfig(cCtx *cli.Context, logger logging.Logger) (*Clai
 	logger.Debugf("Using chain ID: %s", chainID.String())
 
 	if common.IsEmptyString(environment) {
-		environment = getEnvFromNetwork(network)
+		environment = common.GetEnvFromNetwork(network)
 	}
 	logger.Debugf("Using network %s and environment: %s", network, environment)
 
@@ -653,6 +653,7 @@ func readAndValidateClaimConfig(cCtx *cli.Context, logger logging.Logger) (*Clai
 		Network:                   network,
 		RPCUrl:                    rpcUrl,
 		EarnerAddress:             earnerAddress,
+		CallerAddress:             callerAddress,
 		Output:                    output,
 		OutputType:                outputType,
 		Broadcast:                 broadcast,
@@ -677,17 +678,6 @@ func getSidecarUrl(network string) string {
 		return ""
 	} else {
 		return chainMetadata.SidecarHttpRpcURL
-	}
-}
-
-func getEnvFromNetwork(network string) string {
-	switch network {
-	case utils.HoleskyNetworkName:
-		return "testnet"
-	case utils.MainnetNetworkName:
-		return "mainnet"
-	default:
-		return "local"
 	}
 }
 

--- a/pkg/rewards/setclaimer.go
+++ b/pkg/rewards/setclaimer.go
@@ -3,8 +3,6 @@ package rewards
 import (
 	"context"
 	"fmt"
-	"sort"
-
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
@@ -38,7 +36,7 @@ func NewSetClaimerCmd(p utils.Prompter) *cli.Command {
 }
 
 func getSetClaimerFlags() []cli.Flag {
-	baseFlags := []cli.Flag{
+	return []cli.Flag{
 		&flags.NetworkFlag,
 		&flags.ETHRpcUrlFlag,
 		&EarnerAddressFlag,
@@ -46,8 +44,6 @@ func getSetClaimerFlags() []cli.Flag {
 		&ClaimerAddressFlag,
 		&flags.VerboseFlag,
 	}
-	sort.Sort(cli.FlagsByName(baseFlags))
-	return baseFlags
 }
 
 func (s SetClaimerCmd) Execute(cCtx *cli.Context) error {

--- a/pkg/rewards/setclaimer.go
+++ b/pkg/rewards/setclaimer.go
@@ -5,35 +5,34 @@ import (
 	"fmt"
 	"sort"
 
-	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
-
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
-	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	"github.com/Layr-Labs/eigensdk-go/logging"
+	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
 
 	"github.com/urfave/cli/v2"
 )
 
-func SetClaimerCmd(p utils.Prompter) *cli.Command {
-	setClaimerCmd := &cli.Command{
-		Name:      "set-claimer",
-		Usage:     "Set the claimer address for the earner",
-		UsageText: "set-claimer",
-		Description: `
-Set the rewards claimer address for the earner.
-		`,
-		After: telemetry.AfterRunAction(),
-		Flags: getSetClaimerFlags(),
-		Action: func(cCtx *cli.Context) error {
-			return SetClaimer(cCtx, p)
-		},
-	}
+type SetClaimerCmd struct {
+	prompter utils.Prompter
+}
+
+func NewSetClaimerCmd(p utils.Prompter) *cli.Command {
+	delegateCommand := &SetClaimerCmd{prompter: p}
+	setClaimerCmd := command.NewWriteableCallDataCommand(
+		delegateCommand,
+		"set-claimer",
+		"Set the claimer address for the earner",
+		"set-claimer",
+		`Set the rewards claimer address for the earner.`,
+		getSetClaimerFlags(),
+	)
 
 	return setClaimerCmd
 }
@@ -42,21 +41,16 @@ func getSetClaimerFlags() []cli.Flag {
 	baseFlags := []cli.Flag{
 		&flags.NetworkFlag,
 		&flags.ETHRpcUrlFlag,
-		&flags.OutputFileFlag,
-		&flags.OutputTypeFlag,
-		&flags.BroadcastFlag,
 		&EarnerAddressFlag,
 		&RewardsCoordinatorAddressFlag,
 		&ClaimerAddressFlag,
 		&flags.VerboseFlag,
 	}
-
-	allFlags := append(baseFlags, flags.GetSignerFlags()...)
-	sort.Sort(cli.FlagsByName(allFlags))
-	return allFlags
+	sort.Sort(cli.FlagsByName(baseFlags))
+	return baseFlags
 }
 
-func SetClaimer(cCtx *cli.Context, p utils.Prompter) error {
+func (s SetClaimerCmd) Execute(cCtx *cli.Context) error {
 	logger := common.GetLogger(cCtx)
 	config, err := readAndValidateSetClaimerConfig(cCtx, logger)
 	if err != nil {
@@ -78,16 +72,21 @@ func SetClaimer(cCtx *cli.Context, p utils.Prompter) error {
 			return err
 		}
 
-		noSendTxOpts := common.GetNoSendTxOpts(config.EarnerAddress)
+		noSendTxOpts := common.GetNoSendTxOpts(config.CallerAddress)
+		// If caller is a smart contract, we can't estimate gas using geth
+		// since balance of contract can be 0, as it can be called by an EOA
+		// to claim. So we hardcode the gas limit to 150_000 so that we can
+		// create unsigned tx without gas limit estimation from contract bindings
+		if common.IsSmartContractAddress(config.CallerAddress, ethClient) {
+			// Caller is a smart contract
+			noSendTxOpts.GasLimit = 150_000
+		}
 		unsignedTx, err := contractBindings.RewardsCoordinator.SetClaimerFor(noSendTxOpts, config.ClaimerAddress)
 		if err != nil {
 			return eigenSdkUtils.WrapError("failed to create unsigned tx", err)
 		}
 
 		if config.OutputType == string(common.OutputType_Calldata) {
-			if err != nil {
-				return err
-			}
 			calldataHex := gethcommon.Bytes2Hex(unsignedTx.Data())
 			if !common.IsEmptyString(config.Output) {
 				err := common.WriteToFile([]byte(calldataHex), config.Output)
@@ -119,13 +118,13 @@ func SetClaimer(cCtx *cli.Context, p utils.Prompter) error {
 	}
 
 	elWriter, err := common.GetELWriter(
-		config.EarnerAddress,
+		config.CallerAddress,
 		config.SignerConfig,
 		ethClient,
 		elcontracts.Config{
 			RewardsCoordinatorAddress: config.RewardsCoordinatorAddress,
 		},
-		p,
+		s.prompter,
 		config.ChainID,
 		logger,
 	)
@@ -166,6 +165,7 @@ func readAndValidateSetClaimerConfig(cCtx *cli.Context, logger logging.Logger) (
 	if common.IsEmptyString(claimerAddress) {
 		return nil, fmt.Errorf("claimer address is required")
 	}
+	callerAddress := common.PopulateCallerAddress(cCtx, logger, earnerAddress)
 
 	rewardsCoordinatorAddress := cCtx.String(RewardsCoordinatorAddressFlag.Name)
 	var err error
@@ -181,7 +181,7 @@ func readAndValidateSetClaimerConfig(cCtx *cli.Context, logger logging.Logger) (
 	logger.Debugf("Using chain ID: %s", chainID.String())
 
 	if common.IsEmptyString(environment) {
-		environment = getEnvFromNetwork(network)
+		environment = common.GetEnvFromNetwork(network)
 	}
 	logger.Debugf("Using network %s and environment: %s", network, environment)
 
@@ -202,6 +202,7 @@ func readAndValidateSetClaimerConfig(cCtx *cli.Context, logger logging.Logger) (
 		ChainID:                   chainID,
 		SignerConfig:              signerConfig,
 		EarnerAddress:             earnerAddress,
+		CallerAddress:             callerAddress,
 		Output:                    output,
 		OutputType:                outputType,
 	}, nil

--- a/pkg/rewards/show.go
+++ b/pkg/rewards/show.go
@@ -279,7 +279,7 @@ func readAndValidateConfig(cCtx *cli.Context, logger logging.Logger) (*ShowConfi
 	network := cCtx.String(flags.NetworkFlag.Name)
 	env := cCtx.String(EnvironmentFlag.Name)
 	if env == "" {
-		env = getEnvFromNetwork(network)
+		env = common.GetEnvFromNetwork(network)
 	}
 	logger.Debugf("Network: %s, Env: %s", network, env)
 	rewardsCoordinatorAddress := cCtx.String(RewardsCoordinatorAddressFlag.Name)

--- a/pkg/rewards/types.go
+++ b/pkg/rewards/types.go
@@ -21,6 +21,7 @@ type ClaimConfig struct {
 	EarnerAddress             gethcommon.Address
 	RecipientAddress          gethcommon.Address
 	ClaimerAddress            gethcommon.Address
+	CallerAddress             gethcommon.Address
 	Output                    string
 	OutputType                string
 	Broadcast                 bool
@@ -44,6 +45,7 @@ type SetClaimerConfig struct {
 	ChainID                   *big.Int
 	SignerConfig              *types.SignerConfig
 	EarnerAddress             gethcommon.Address
+	CallerAddress             gethcommon.Address
 	Output                    string
 	OutputType                string
 }

--- a/pkg/user/admin/accept.go
+++ b/pkg/user/admin/accept.go
@@ -145,7 +145,7 @@ func readAndValidateAcceptAdminConfig(
 	logger logging.Logger,
 ) (*acceptAdminConfig, error) {
 	accountAddress := gethcommon.HexToAddress(cliContext.String(AccountAddressFlag.Name))
-	callerAddress := user.PopulateCallerAddress(cliContext, logger, accountAddress)
+	callerAddress := common.PopulateCallerAddress(cliContext, logger, accountAddress)
 	ethRpcUrl := cliContext.String(flags.ETHRpcUrlFlag.Name)
 	network := cliContext.String(flags.NetworkFlag.Name)
 	environment := cliContext.String(flags.EnvironmentFlag.Name)


### PR DESCRIPTION
### Fixes
 - Fixes rewards commands to specify a CallerAddress to support printing call data.
 - Refactors call data writeable commands to all implement a BaseCommand and wrap it in a CalldataWriteableCommand to generalize flag handling and command creation.
 - Small simplifications to reuse existing helper functions.

### What Changed?
 - BaseCommand and CalldataWriteableCommand introduced to generalize command handling.
