### PR TITLE
Updating the README with integration testing environment details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ Links to specific sections are provided below.
 
 If you see any issues in documentation please create an issue or PR [here](https://github.com/Layr-Labs/eigenlayer-docs)
 
+## Integration Testing
+Integration testing uses Anvil to generate a reproducible state for the network to be tested against. 
+
+### Forge & Anvil
+The CLI package leverages tooling from the [eigensdk-go](https://github.com/Layr-Labs/eigensdk-go) to run [Forge](https://github.com/foundry-rs/foundry/tree/master/crates/forge) tests against an [Anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil) server based on a predefined network state.
+This allows the tests to run against a reproducible environment. See the [Run anvil chain](https://github.com/Layr-Labs/eigenlayer-cli/blob/master/.github/workflows/integration-test.yml#L28-L30)
+step in the integration test workflow. See the [eigensdk-go README.md - Anvil](https://github.com/Layr-Labs/eigensdk-go/blob/dev/README.md)
+for further discussion on how this environment state is generated and stored.
+
 ## Release Process
 To release a new version of the CLI, follow the steps below:
 > Note: You need to have write permission to this repo to release new version


### PR DESCRIPTION
## Overview
The package README didn't have any context around integration testing. This PR adds context on the topic.

## What Changed?
Added integration test README section.

## TODO
Add further context to the eigensdk-go README for anvil setup and usage.
Update this README again with details on how BATS is used and how to execute those tests once they merged to master.