### PR TITLE
fix: increase timeout for sidecar client

### DIFF
--- a/pkg/clients/sidecar/client.go
+++ b/pkg/clients/sidecar/client.go
@@ -40,7 +40,7 @@ func NewSidecarRewardsClient(url string, opts ...gateway.ClientOption) (rewardsV
 				"x-sidecar-source": "eigenlayer-cli",
 			},
 		},
-		Timeout: 30 * time.Second,
+		Timeout: 300 * time.Second,
 	}
 
 	if len(opts) == 0 {


### PR DESCRIPTION
### What Changed?

Increase sidecar client timeout since generating rewards data can take a "long" time if not already cached.