### PR TITLE
Updating Ubuntu version for release task.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - run: make tests
   release:
     needs: [lint, test]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Slashing Release Workflow Fix
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101

The Ubuntu version we're using is retired.

### What Changed?
 - Fixing failed [release workflow](https://github.com/Layr-Labs/eigenlayer-cli/actions/runs/14502277031/job/40684621631).