### PR TITLE
fix: PrettyPrintStruct was panicing due to incorrect reflect parsing

### DIFF
--- a/pkg/internal/common/print.go
+++ b/pkg/internal/common/print.go
@@ -7,6 +7,18 @@ import (
 
 func PrettyPrintStruct(data interface{}) {
 	v := reflect.ValueOf(data)
+
+	// If it's a pointer, get the underlying element
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	// Check if it's a struct
+	if v.Kind() != reflect.Struct {
+		fmt.Println("Not a struct or pointer to struct")
+		return
+	}
+
 	typeOfS := v.Type()
 
 	for i := 0; i < v.NumField(); i++ {


### PR DESCRIPTION
Original error:

```
------- Claim generated -------
panic: reflect: call of reflect.Value.NumField on ptr Value

goroutine 1 [running]:
reflect.flag.mustBe(...)
        /Users/seanmcgary/Code/gocode/go1.23.6/src/reflect/value.go:218
reflect.Value.NumField({0x10590df60?, 0x140004ddd60?, 0x1400061efe8?})
        /Users/seanmcgary/Code/gocode/go1.23.6/src/reflect/value.go:2111 +0x90
github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common.PrettyPrintStruct({0x10590df60?, 0x140004ddd60?})
        /Users/seanmcgary/Code/eigenlayer-cli/pkg/internal/common/print.go:12 +0x1f0
github.com/Layr-Labs/eigenlayer-cli/pkg/rewards.broadcastClaims(0x14000000480, 0x1400051a680, {0x105b86a60, 0x1400051a5d0}, {0x105b80aa0, 0x106411500}, {0x105b7ec30, 0x106411500}, {0x1400061f6e0, 0x1, ...})
        /Users/seanmcgary/Code/eigenlayer-cli/pkg/rewards/claim.go:438 +0x8b0
github.com/Layr-Labs/eigenlayer-cli/pkg/rewards.ClaimCmd.Execute({{0x105b80aa0?, 0x106411500?}}, 0x1400026e2c0)
        /Users/seanmcgary/Code/eigenlayer-cli/pkg/rewards/claim.go:315 +0x3d8
github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command.NewWriteableCallDataCommand.func1(0x1400026e2c0?)
        /Users/seanmcgary/Code/eigenlayer-cli/pkg/internal/command/NewWriteableCallDataCommand.go:29 +0x30
github.com/urfave/cli/v2.(*Command).Run(0x140001551e0, 0x1400026e2c0, {0x140000c0300, 0x10, 0x10})
        /Users/seanmcgary/.gvm/pkgsets/go1.23.6/global/pkg/mod/github.com/urfave/cli/v2@v2.27.5/command.go:276 +0x600
github.com/urfave/cli/v2.(*Command).Run(0x14000155600, 0x1400026e200, {0x14000000360, 0x11, 0x11})
        /Users/seanmcgary/.gvm/pkgsets/go1.23.6/global/pkg/mod/github.com/urfave/cli/v2@v2.27.5/command.go:269 +0x83c
github.com/urfave/cli/v2.(*Command).Run(0x140002bc000, 0x1400026e0c0, {0x140001c4000, 0x12, 0x12})
        /Users/seanmcgary/.gvm/pkgsets/go1.23.6/global/pkg/mod/github.com/urfave/cli/v2@v2.27.5/command.go:269 +0x83c
github.com/urfave/cli/v2.(*App).RunContext(0x140002b9400, {0x105b7ec30, 0x106411500}, {0x140001c4000, 0x12, 0x12})
        /Users/seanmcgary/.gvm/pkgsets/go1.23.6/global/pkg/mod/github.com/urfave/cli/v2@v2.27.5/app.go:333 +0x51c
github.com/urfave/cli/v2.(*App).Run(...)
        /Users/seanmcgary/.gvm/pkgsets/go1.23.6/global/pkg/mod/github.com/urfave/cli/v2@v2.27.5/app.go:307
main.main()
        /Users/seanmcgary/Code/eigenlayer-cli/cmd/eigenlayer/main.go:48 +0x4f4
exit status 2
```

### What Changed?
This change fixes the reflect logic to correctly print the object and not panic.
