### PR TITLE
fix: enforce operator address flag

### DIFF
--- a/pkg/operator/allocations/set_allocation_delay.go
+++ b/pkg/operator/allocations/set_allocation_delay.go
@@ -169,6 +169,11 @@ func readAndValidateAllocationDelayConfig(c *cli.Context, logger logging.Logger)
 	broadcast := c.Bool(flags.BroadcastFlag.Name)
 	operatorAddress := c.String(flags.OperatorAddressFlag.Name)
 
+	if common.IsEmptyString(operatorAddress) {
+		logger.Error("--operator-address flag must be set")
+		return nil, fmt.Errorf("Empty operator address provided")
+	}
+
 	callerAddress := c.String(flags.CallerAddressFlag.Name)
 	if common.IsEmptyString(callerAddress) {
 		logger.Infof("Caller address not provided. Using operator address (%s) as caller address", operatorAddress)

--- a/pkg/operator/allocations/update.go
+++ b/pkg/operator/allocations/update.go
@@ -447,6 +447,11 @@ func readAndValidateUpdateFlags(cCtx *cli.Context, logger logging.Logger) (*upda
 	isSilent := cCtx.Bool(flags.SilentFlag.Name)
 
 	operatorAddress := cCtx.String(flags.OperatorAddressFlag.Name)
+	if common.IsEmptyString(operatorAddress) {
+		logger.Error("--operator-address flag must be set")
+		return nil, fmt.Errorf("Empty operator address provided")
+	}
+
 	callerAddress := cCtx.String(flags.CallerAddressFlag.Name)
 	if common.IsEmptyString(callerAddress) {
 		logger.Infof("Caller address not provided. Using operator address (%s) as caller address", operatorAddress)

--- a/pkg/operator/deregister_operator_sets.go
+++ b/pkg/operator/deregister_operator_sets.go
@@ -168,8 +168,14 @@ func readAndValidateDeregisterConfig(cCtx *cli.Context, logger logging.Logger) (
 	broadcast := cCtx.Bool(flags.BroadcastFlag.Name)
 	isSilent := cCtx.Bool(flags.SilentFlag.Name)
 
-	operatorAddress := gethcommon.HexToAddress(cCtx.String(flags.OperatorAddressFlag.Name))
-	callerAddress := common.PopulateCallerAddress(cCtx, logger, operatorAddress, flags.OperatorAddressFlag.Name)
+	operatorAddressString := cCtx.String(flags.OperatorAddressFlag.Name)
+	if common.IsEmptyString(operatorAddressString) {
+		logger.Error("--operator-address flag must be set")
+		return nil, fmt.Errorf("Empty operator address provided")
+	}
+
+	operatorAddress := gethcommon.HexToAddress(operatorAddressString)
+	callerAddress := common.PopulateCallerAddress(cCtx, logger, operatorAddress, operatorAddressString)
 	avsAddress := gethcommon.HexToAddress(cCtx.String(flags.AVSAddressFlag.Name))
 
 	// Get signerConfig

--- a/pkg/operator/get_operator_split.go
+++ b/pkg/operator/get_operator_split.go
@@ -1,6 +1,7 @@
 package operator
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
@@ -118,7 +119,13 @@ func readAndValidateGetOperatorSplitConfig(
 	}
 	logger.Debugf("Using Rewards Coordinator address: %s", rewardsCoordinatorAddress)
 
-	operatorAddress := gethcommon.HexToAddress(cCtx.String(flags.OperatorAddressFlag.Name))
+	operatorAddressString := cCtx.String(flags.OperatorAddressFlag.Name)
+	if common.IsEmptyString(operatorAddressString) {
+		logger.Error("--operator-address flag must be set")
+		return nil, fmt.Errorf("Empty operator address provided")
+	}
+	operatorAddress := gethcommon.HexToAddress(operatorAddressString)
+
 	logger.Infof("Using operator address: %s", operatorAddress.String())
 
 	avsAddress := gethcommon.HexToAddress(cCtx.String(split.AVSAddressFlag.Name))

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"fmt"
+
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
@@ -154,8 +155,14 @@ func readAndValidateRegisterOperatorSetsConfig(cCtx *cli.Context, logger logging
 	broadcast := cCtx.Bool(flags.BroadcastFlag.Name)
 	isSilent := cCtx.Bool(flags.SilentFlag.Name)
 
-	operatorAddress := gethcommon.HexToAddress(cCtx.String(flags.OperatorAddressFlag.Name))
-	callerAddress := common.PopulateCallerAddress(cCtx, logger, operatorAddress, flags.OperatorAddressFlag.Name)
+	operatorAddressString := cCtx.String(flags.OperatorAddressFlag.Name)
+	if common.IsEmptyString(operatorAddressString) {
+		logger.Error("--operator-address flag must be set")
+		return nil, fmt.Errorf("Empty operator address provided")
+	}
+	operatorAddress := gethcommon.HexToAddress(operatorAddressString)
+
+	callerAddress := common.PopulateCallerAddress(cCtx, logger, operatorAddress, operatorAddressString)
 	avsAddress := gethcommon.HexToAddress(cCtx.String(flags.AVSAddressFlag.Name))
 
 	// Get signerConfig

--- a/pkg/operator/set_operator_split.go
+++ b/pkg/operator/set_operator_split.go
@@ -200,9 +200,15 @@ func readAndValidateSetOperatorSplitConfig(
 	}
 	logger.Debugf("Using Rewards Coordinator address: %s", rewardsCoordinatorAddress)
 
-	operatorAddress := gethcommon.HexToAddress(cCtx.String(flags.OperatorAddressFlag.Name))
+	operatorAddressString := cCtx.String(flags.OperatorAddressFlag.Name)
+	if common.IsEmptyString(operatorAddressString) {
+		logger.Error("--operator-address flag must be set")
+		return nil, fmt.Errorf("Empty operator address provided")
+	}
+
+	operatorAddress := gethcommon.HexToAddress(cCtx.String(operatorAddressString))
 	logger.Infof("Using operator address: %s", operatorAddress.String())
-	callerAddress := common.PopulateCallerAddress(cCtx, logger, operatorAddress, flags.OperatorAddressFlag.Name)
+	callerAddress := common.PopulateCallerAddress(cCtx, logger, operatorAddress, operatorAddressString)
 
 	avsAddress := gethcommon.HexToAddress(cCtx.String(split.AVSAddressFlag.Name))
 

--- a/pkg/operator/set_operator_split.go
+++ b/pkg/operator/set_operator_split.go
@@ -206,7 +206,7 @@ func readAndValidateSetOperatorSplitConfig(
 		return nil, fmt.Errorf("Empty operator address provided")
 	}
 
-	operatorAddress := gethcommon.HexToAddress(cCtx.String(operatorAddressString))
+	operatorAddress := gethcommon.HexToAddress(operatorAddressString)
 	logger.Infof("Using operator address: %s", operatorAddress.String())
 	callerAddress := common.PopulateCallerAddress(cCtx, logger, operatorAddress, operatorAddressString)
 


### PR DESCRIPTION
Fixes # .

This PR makes the `--operator-address` flag a requirement for the `operator set-delay` command. This is needed as UAM supports signing with a private key that is != operator's private key.

### What Changed?
<!-- Describe the changes you made in this PR -->
Added a check for the empty `--operator-address` string argument.