### PR TITLE
fix: fix operator set registration command

### DIFF
--- a/pkg/internal/common/flags/general.go
+++ b/pkg/internal/common/flags/general.go
@@ -132,4 +132,16 @@ var (
 		Usage:   "Used to execute an action on behalf of another user. See User Access Management documents for more details.",
 		EnvVars: []string{"CALLER_ADDRESS"},
 	}
+	RegistryCoordinatorAddressFlag = cli.StringFlag{
+		Name:    "registry-coordinator-address",
+		Aliases: []string{"rca"},
+		Usage:   "Address of the registry coordinator contract. This is required for registering an operator for operator sets",
+		EnvVars: []string{"REGISTRY_COORDINATOR_ADDRESS"},
+	}
+	BlsPrivateKeyFlag = cli.StringFlag{
+		Name:    "bls-private-key",
+		Aliases: []string{"bls"},
+		Usage:   "BLS private key of Operator for Operator Set registration",
+		EnvVars: []string{"BLS_PRIVATE_KEY"},
+	}
 )

--- a/pkg/internal/common/helper.go
+++ b/pkg/internal/common/helper.go
@@ -379,7 +379,7 @@ func GetTransactionLink(txHash string, chainId *big.Int) string {
 	if !ok {
 		return txHash
 	} else {
-		return fmt.Sprintf("%s/%s", chainMetadata.BlockExplorerUrl, txHash)
+		return fmt.Sprintf("%s/tx/%s", chainMetadata.BlockExplorerUrl, txHash)
 	}
 }
 

--- a/pkg/internal/common/helper_test.go
+++ b/pkg/internal/common/helper_test.go
@@ -24,13 +24,13 @@ func TestGetTransactionLink(t *testing.T) {
 			name:           "valid mainnet tx hash",
 			chainID:        big.NewInt(1),
 			txHash:         "0x123",
-			expectedTxLink: fmt.Sprintf("%s/%s", utils.MainnetBlockExplorerUrl, "0x123"),
+			expectedTxLink: fmt.Sprintf("%s/tx/%s", utils.MainnetBlockExplorerUrl, "0x123"),
 		},
 		{
 			name:           "valid holesky tx hash",
 			chainID:        big.NewInt(17000),
 			txHash:         "0x123",
-			expectedTxLink: fmt.Sprintf("%s/%s", utils.HoleskyBlockExplorerUrl, "0x123"),
+			expectedTxLink: fmt.Sprintf("%s/tx/%s", utils.HoleskyBlockExplorerUrl, "0x123"),
 		},
 		{
 			name:           "valid custom chain tx hash",

--- a/pkg/keys/import.go
+++ b/pkg/keys/import.go
@@ -3,14 +3,12 @@ package keys
 import (
 	"crypto/ecdsa"
 	"fmt"
-	"math/big"
 	"strings"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/telemetry"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 
-	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/urfave/cli/v2"
 )
@@ -104,29 +102,9 @@ This command will import keys in $HOME/.eigenlayer/operator_keys/ location
 				}
 				return saveEcdsaKey(keyName, p, privateKeyPair, insecure, stdInPassword, readFromPipe, "")
 			case KeyTypeBLS:
-				privateKeyBigInt := new(big.Int)
-				_, ok := privateKeyBigInt.SetString(privateKey, 10)
-				var blsKeyPair *bls.KeyPair
-				var err error
-				if ok {
-					fmt.Println("Importing from large integer")
-					blsKeyPair, err = bls.NewKeyPairFromString(privateKey)
-					if err != nil {
-						return err
-					}
-				} else {
-					// Try to parse as hex
-					fmt.Println("Importing from hex")
-					z := new(big.Int)
-					privateKey = common.Trim0x(privateKey)
-					_, ok := z.SetString(privateKey, 16)
-					if !ok {
-						return ErrInvalidHexPrivateKey
-					}
-					blsKeyPair, err = bls.NewKeyPairFromString(z.String())
-					if err != nil {
-						return err
-					}
+				blsKeyPair, err := ParseBlsPrivateKey(privateKey)
+				if err != nil {
+					return err
 				}
 				return saveBlsKey(keyName, p, blsKeyPair, insecure, stdInPassword, readFromPipe)
 			default:

--- a/pkg/keys/utils.go
+++ b/pkg/keys/utils.go
@@ -1,0 +1,38 @@
+package keys
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
+)
+
+// ParseBlsPrivateKey parses a BLS private key from a string either in hex or large integer format.
+func ParseBlsPrivateKey(privateKey string) (*bls.KeyPair, error) {
+	privateKeyBigInt := new(big.Int)
+	_, ok := privateKeyBigInt.SetString(privateKey, 10)
+	var blsKeyPair *bls.KeyPair
+	var err error
+	if ok {
+		fmt.Println("Importing from large integer")
+		blsKeyPair, err = bls.NewKeyPairFromString(privateKey)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// Try to parse as hex
+		fmt.Println("Importing from hex")
+		z := new(big.Int)
+		privateKey = common.Trim0x(privateKey)
+		_, ok := z.SetString(privateKey, 16)
+		if !ok {
+			return nil, ErrInvalidHexPrivateKey
+		}
+		blsKeyPair, err = bls.NewKeyPairFromString(z.String())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return blsKeyPair, nil
+}

--- a/pkg/operator/register_operator_sets.go
+++ b/pkg/operator/register_operator_sets.go
@@ -2,16 +2,15 @@ package operator
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/command"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/internal/common/flags"
+	"github.com/Layr-Labs/eigenlayer-cli/pkg/keys"
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/utils"
 
 	"github.com/Layr-Labs/eigensdk-go/chainio/clients/elcontracts"
 	allocationmanager "github.com/Layr-Labs/eigensdk-go/contracts/bindings/AllocationManager"
-	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/Layr-Labs/eigensdk-go/logging"
 	eigenSdkUtils "github.com/Layr-Labs/eigensdk-go/utils"
 
@@ -204,18 +203,9 @@ func readAndValidateRegisterOperatorSetsConfig(cCtx *cli.Context, logger logging
 		return nil, fmt.Errorf("Empty BLS private key provided")
 	}
 
-	privateKeyBigInt := new(big.Int)
-	_, ok := privateKeyBigInt.SetString(blsPrivateKey, 10)
-	var blsKeyPair *bls.KeyPair
-	if ok {
-		blsKeyPair, err = bls.NewKeyPairFromString(blsPrivateKey)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if !ok {
-		logger.Error("failed to create BLS key pair")
-		return nil, fmt.Errorf("failed to create BLS key pair")
+	blsKeyPair, err := keys.ParseBlsPrivateKey(blsPrivateKey)
+	if err != nil {
+		return nil, err
 	}
 
 	config := &RegisterConfig{

--- a/pkg/operator/types.go
+++ b/pkg/operator/types.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/Layr-Labs/eigenlayer-cli/pkg/types"
+	"github.com/Layr-Labs/eigensdk-go/crypto/bls"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -25,18 +26,20 @@ type DeregisterConfig struct {
 }
 
 type RegisterConfig struct {
-	avsAddress               common.Address
-	operatorSetIds           []uint32
-	operatorAddress          common.Address
-	callerAddress            common.Address
-	network                  string
-	environment              string
-	broadcast                bool
-	rpcUrl                   string
-	chainID                  *big.Int
-	signerConfig             *types.SignerConfig
-	output                   string
-	outputType               string
-	delegationManagerAddress common.Address
-	isSilent                 bool
+	avsAddress                 common.Address
+	operatorSetIds             []uint32
+	operatorAddress            common.Address
+	callerAddress              common.Address
+	network                    string
+	environment                string
+	broadcast                  bool
+	rpcUrl                     string
+	chainID                    *big.Int
+	signerConfig               *types.SignerConfig
+	output                     string
+	outputType                 string
+	delegationManagerAddress   common.Address
+	isSilent                   bool
+	registryCoordinatorAddress common.Address
+	blsKeyPair                 *bls.KeyPair
 }


### PR DESCRIPTION
Fixes # .
- Fixes the `register-operator-sets` command
- Fixes the tx link

### What Changed?
<!-- Describe the changes you made in this PR -->
This PR fixes the `register-operator-sets` command, by adding flags for the `RegistryCoordinator` address and `BlsPrivateKey` needed for registration to an Operator Set
